### PR TITLE
Allow plain-http loopback URLs for local development (require_https: false)

### DIFF
--- a/lib/attesto/config.ex
+++ b/lib/attesto/config.ex
@@ -29,6 +29,13 @@ defmodule Attesto.Config do
       mounted at, used to derive `token_endpoint_url/1` (the URL a DPoP
       proof's `htu` must sign, and the URL OAuth metadata would publish).
       Defaults to `"/oauth/token"`.
+    * `:require_https` - enforce the RFC 8414 §2 `https` scheme on the
+      issuer. Defaults to `true`. Setting `false` admits a plain-`http`
+      issuer ONLY when its host is the loopback interface
+      (`Attesto.LoopbackHost.loopback?/1`: `localhost`, `*.localhost`,
+      `127.0.0.0/8`, `::1`) - the local-development case where TLS adds no
+      transport security (the RFC 8252 §8.3 loopback reasoning). A
+      non-loopback `http` issuer is rejected regardless of this flag.
 
   ## Reserved claims
 
@@ -50,7 +57,8 @@ defmodule Attesto.Config do
     principal_kind_claim: "principal_kind",
     default_lifetime_seconds: 900,
     token_endpoint_path: "/oauth/token",
-    access_token_header_typ: "at+jwt"
+    access_token_header_typ: "at+jwt",
+    require_https: true
   ]
 
   @type t :: %__MODULE__{
@@ -61,7 +69,8 @@ defmodule Attesto.Config do
           principal_kind_claim: String.t(),
           default_lifetime_seconds: pos_integer(),
           token_endpoint_path: String.t(),
-          access_token_header_typ: String.t() | nil
+          access_token_header_typ: String.t() | nil,
+          require_https: boolean()
         }
 
   # `acr` / `auth_time` are the RFC 9470 / OIDC Core authentication-context
@@ -101,8 +110,9 @@ defmodule Attesto.Config do
   def new(opts) when is_list(opts) do
     config = struct!(__MODULE__, opts)
 
+    validate_boolean!(:require_https, config.require_https)
     validate_binary!(:issuer, config.issuer)
-    validate_issuer_url!(config.issuer)
+    validate_issuer_url!(config.issuer, config.require_https)
     validate_binary!(:audience, config.audience)
     validate_keystore!(config.keystore)
     validate_principal_kind_claim!(config.principal_kind_claim)
@@ -146,14 +156,19 @@ defmodule Attesto.Config do
   # RFC 8414 §2: the issuer identifier MUST be an `https` URL with a host
   # and no query or fragment. The same value is the JWT `iss`, so enforcing
   # the metadata shape here keeps a misconfigured deployment from
-  # publishing (and minting tokens under) a non-conformant issuer.
-  defp validate_issuer_url!(issuer) do
+  # publishing (and minting tokens under) a non-conformant issuer. The one
+  # deviation is `require_https: false` + a loopback host: plain `http` to
+  # loopback never leaves the machine (RFC 8252 §8.3's reasoning), so a
+  # local-development issuer like `http://localhost:4000` is admitted.
+  defp validate_issuer_url!(issuer, require_https) do
     uri = URI.parse(issuer)
 
     cond do
-      uri.scheme != "https" ->
+      not issuer_scheme_allowed?(uri, require_https) ->
         raise ArgumentError,
-              "Attesto.Config :issuer must be an https URL (RFC 8414 §2); got #{inspect(issuer)}"
+              "Attesto.Config :issuer must be an https URL (RFC 8414 §2); got #{inspect(issuer)}. " <>
+                "Plain http is admitted only for a loopback host (localhost, *.localhost, " <>
+                "127.0.0.0/8, ::1) with `require_https: false`."
 
       uri.host in [nil, ""] ->
         raise ArgumentError, "Attesto.Config :issuer must include a host; got #{inspect(issuer)}"
@@ -170,6 +185,18 @@ defmodule Attesto.Config do
 
       true ->
         :ok
+    end
+  end
+
+  defp issuer_scheme_allowed?(%URI{scheme: "https"}, _require_https), do: true
+
+  defp issuer_scheme_allowed?(%URI{scheme: "http", host: host}, false), do: Attesto.LoopbackHost.loopback?(host)
+
+  defp issuer_scheme_allowed?(_uri, _require_https), do: false
+
+  defp validate_boolean!(field, value) do
+    if !is_boolean(value) do
+      raise ArgumentError, "Attesto.Config #{field} must be a boolean; got #{inspect(value)}"
     end
   end
 

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -413,25 +413,35 @@ defmodule Attesto.DPoP do
   defp check_htu(_claims, _opts), do: {:error, :invalid_htu}
 
   # RFC 9449 §4.3: compare the effective target URI without query/fragment.
-  # URI scheme and host are case-insensitive, and an explicit HTTPS default
-  # port is equivalent to an omitted port.
+  # URI scheme and host are case-insensitive, and an explicit scheme-default
+  # port is equivalent to an omitted port. A plain-`http` htu is admitted only
+  # for a loopback host (`Attesto.LoopbackHost`) - the local-development token
+  # endpoint. It can only ever MATCH when the expected URL (derived from the
+  # configured issuer) is itself http+loopback, which `Attesto.Config` admits
+  # only under `require_https: false`; against an https deployment the scheme
+  # in the normalized tuple still differs and the proof is rejected.
   defp normalize_htu(uri) do
     parsed = URI.parse(uri)
     scheme = parsed.scheme && String.downcase(parsed.scheme)
     host = parsed.host && String.downcase(parsed.host)
 
     cond do
-      scheme != "https" -> {:error, :invalid_htu}
+      not htu_scheme_allowed?(scheme, host) -> {:error, :invalid_htu}
       is_nil(host) or host == "" -> {:error, :invalid_htu}
       not is_nil(parsed.userinfo) -> {:error, :invalid_htu}
-      true -> {:ok, {scheme, host, normalize_htu_port(parsed.port), parsed.path || ""}}
+      true -> {:ok, {scheme, host, normalize_htu_port(scheme, parsed.port), parsed.path || ""}}
     end
   rescue
     _ -> {:error, :invalid_htu}
   end
 
-  defp normalize_htu_port(443), do: nil
-  defp normalize_htu_port(port), do: port
+  defp htu_scheme_allowed?("https", _host), do: true
+  defp htu_scheme_allowed?("http", host), do: Attesto.LoopbackHost.loopback?(host)
+  defp htu_scheme_allowed?(_scheme, _host), do: false
+
+  defp normalize_htu_port("https", 443), do: nil
+  defp normalize_htu_port("http", 80), do: nil
+  defp normalize_htu_port(_scheme, port), do: port
 
   defp check_iat(%{"iat" => iat}, opts) when is_integer(iat) and iat >= 0 do
     now = unix_now(opts)

--- a/lib/attesto/loopback_host.ex
+++ b/lib/attesto/loopback_host.ex
@@ -1,0 +1,49 @@
+defmodule Attesto.LoopbackHost do
+  @moduledoc """
+  Loopback-host detection backing the development-only plain-`http` carve-outs.
+
+  RFC 8414 §2 (issuer identifiers), RFC 9728 §2 (protected-resource
+  identifiers) and RFC 9449 §4.3 (DPoP `htu`) all specify `https` URLs, and
+  Attesto enforces that by default. The one deployment where that enforcement
+  only hurts is local development on the loopback interface: traffic to
+  loopback never leaves the machine, so TLS adds no transport security there -
+  the same reasoning RFC 8252 §8.3 uses to exempt loopback redirect URIs from
+  the `https` requirement, and the practice MCP tooling expects
+  (`http://localhost` development servers).
+
+  A host qualifies as loopback only when it cannot name a remote peer:
+  `localhost` and any `*.localhost` name (RFC 6761 §6.3 - resolvers treat
+  these as loopback), an IPv4 address in `127.0.0.0/8` (RFC 5735 §3), or the
+  IPv6 loopback `::1`. A DNS name that merely *resolves* to loopback does not
+  qualify: the string is all this check ever sees, and any other name may
+  resolve differently for another party.
+  """
+
+  @doc """
+  Whether `host` (a `URI` host component) names the loopback interface.
+
+  Accepts the IPv6 loopback both bracketed (`"[::1]"`, as some `URI` parsers
+  retain it) and bare (`"::1"`). Any non-binary input is `false`.
+  """
+  @spec loopback?(term()) :: boolean()
+  def loopback?(host) when is_binary(host) do
+    case String.downcase(host) do
+      "localhost" -> true
+      "::1" -> true
+      "[::1]" -> true
+      down -> String.ends_with?(down, ".localhost") or loopback_ipv4?(down)
+    end
+  end
+
+  def loopback?(_host), do: false
+
+  # Strict IPv4 parsing so `127.1` / `0177.0.0.1`-style shorthands (which
+  # `:inet.parse_address/1` would admit) don't widen the carve-out beyond
+  # dotted-quad `127.0.0.0/8` literals.
+  defp loopback_ipv4?(host) do
+    case :inet.parse_ipv4strict_address(String.to_charlist(host)) do
+      {:ok, {127, _, _, _}} -> true
+      _ -> false
+    end
+  end
+end

--- a/lib/attesto/plug/oauth_error.ex
+++ b/lib/attesto/plug/oauth_error.ex
@@ -163,10 +163,11 @@ if Code.ensure_loaded?(Plug.Conn) do
           # blank / non-https / malformed value rather than render an unusable
           # param or crash quoting a non-string. (The Phoenix layer validates
           # this at config build; this guards a core-only caller passing it
-          # directly.) A loopback `http://` dev resource cannot use this static
-          # value - by RFC 9728 the pointer is https - so a host that needs an
-          # http loopback pointer in dev supplies the whole challenge via the
-          # `:www_authenticate` hook, which bypasses this builder.
+          # directly.) The one admitted deviation is a plain-`http` pointer at
+          # a LOOPBACK host - the local-development resource
+          # (`Attesto.LoopbackHost`) whose challenge would otherwise carry no
+          # discovery pointer at all; a non-loopback `http` value is still
+          # dropped.
           if metadata_url?(url), do: [{"resource_metadata", url}], else: []
 
         _ ->
@@ -176,10 +177,16 @@ if Code.ensure_loaded?(Plug.Conn) do
 
     defp metadata_url?(url) do
       not Regex.match?(~r/%(?![0-9A-Fa-f]{2})/, url) and
-        match?(
-          {:ok, %URI{scheme: "https", host: h, fragment: nil}} when is_binary(h) and h != "",
-          URI.new(url)
-        )
+        case URI.new(url) do
+          {:ok, %URI{scheme: "https", host: h, fragment: nil}} when is_binary(h) and h != "" ->
+            true
+
+          {:ok, %URI{scheme: "http", host: h, fragment: nil}} when is_binary(h) and h != "" ->
+            Attesto.LoopbackHost.loopback?(h)
+
+          _ ->
+            false
+        end
     end
 
     defp maybe_put_dpop_nonce(conn, nil), do: conn

--- a/lib/attesto/protected_resource_metadata.ex
+++ b/lib/attesto/protected_resource_metadata.ex
@@ -112,24 +112,33 @@ defmodule Attesto.ProtectedResourceMetadata do
   # absolute URI with a host and no fragment (RFC 3986; RFC 9728 §2 - it is the
   # `https` URL a client dereferences), so a malformed value fails fast rather
   # than publishing a non-conformant REQUIRED member. (RFC 9728 §2 specifies the
-  # `https` scheme; that is the host's deployment choice and is not enforced here
-  # so a loopback `http` development resource still renders.)
+  # `https` scheme; under `require_https: false` a loopback `http` development
+  # resource still renders - the same carve-out `Attesto.Config` grants the
+  # issuer.)
   defp resource(config, opts) do
     case Keyword.get(opts, :resource) do
-      nil -> require_resource_identifier!(config.audience)
-      resource when is_binary(resource) and resource != "" -> require_resource_identifier!(resource)
-      other -> raise ArgumentError, malformed_resource_message(other)
+      nil ->
+        require_resource_identifier!(config.audience, config.require_https)
+
+      resource when is_binary(resource) and resource != "" ->
+        require_resource_identifier!(resource, config.require_https)
+
+      other ->
+        raise ArgumentError, malformed_resource_message(other)
     end
   end
 
   # RFC 9728 §1.2/§2: the `resource` identifier is an `https` URL with a host and
-  # no fragment. `URI.new/1` (unlike `URI.parse/1`) rejects whitespace/control
-  # characters but still accepts an invalid percent-escape (a `%` not followed by
-  # two hex digits, e.g. `%ZZ`), so that is rejected explicitly first.
-  defp require_resource_identifier!(url) do
+  # no fragment (`http` admitted only for a loopback host under
+  # `require_https: false`). `URI.new/1` (unlike `URI.parse/1`) rejects
+  # whitespace/control characters but still accepts an invalid percent-escape (a
+  # `%` not followed by two hex digits, e.g. `%ZZ`), so that is rejected
+  # explicitly first.
+  defp require_resource_identifier!(url, require_https) do
     with false <- invalid_percent_encoding?(url),
-         {:ok, %URI{scheme: "https", host: host, fragment: nil}} <- URI.new(url),
-         true <- is_binary(host) and host != "" do
+         {:ok, %URI{scheme: scheme, host: host, fragment: nil}} <- URI.new(url),
+         true <- is_binary(host) and host != "",
+         true <- scheme == "https" or (scheme == "http" and not require_https and Attesto.LoopbackHost.loopback?(host)) do
       url
     else
       _ -> raise ArgumentError, malformed_resource_message(url)

--- a/test/attesto/config_test.exs
+++ b/test/attesto/config_test.exs
@@ -179,6 +179,43 @@ defmodule Attesto.ConfigTest do
     end
   end
 
+  describe "new/1 require_https (loopback http development)" do
+    test "defaults to true: an http issuer is rejected even at a loopback host" do
+      assert_raise ArgumentError, ~r/must be an https URL/, fn ->
+        Config.new(base_opts(issuer: "http://localhost:4000"))
+      end
+    end
+
+    test "require_https: false admits an http issuer at a loopback host" do
+      for issuer <- [
+            "http://localhost:4000",
+            "http://app.localhost:4000",
+            "http://127.0.0.1:4000",
+            "http://[::1]:4000"
+          ] do
+        config = Config.new(base_opts(issuer: issuer, require_https: false))
+        assert config.issuer == issuer
+      end
+    end
+
+    test "require_https: false still rejects an http issuer at a non-loopback host" do
+      assert_raise ArgumentError, ~r/must be an https URL/, fn ->
+        Config.new(base_opts(issuer: "http://api.example.com", require_https: false))
+      end
+    end
+
+    test "an admitted loopback http issuer still derives the token endpoint URL" do
+      config = Config.new(base_opts(issuer: "http://localhost:4000", require_https: false))
+      assert Config.token_endpoint_url(config) == "http://localhost:4000/oauth/token"
+    end
+
+    test "raises on a non-boolean require_https" do
+      assert_raise ArgumentError, ~r/must be a boolean/, fn ->
+        Config.new(base_opts(require_https: "false"))
+      end
+    end
+  end
+
   describe "principal_kind/2" do
     test "finds a configured kind by its claim_value" do
       config = Config.new(base_opts())

--- a/test/attesto/dpop_test.exs
+++ b/test/attesto/dpop_test.exs
@@ -404,6 +404,27 @@ defmodule Attesto.DPoPTest do
       assert {:error, :invalid_htu} = DPoP.verify_proof(proof, base_opts(http_uri: live_uri))
     end
 
+    test "accepts an http htu at a loopback host (local development token endpoint)" do
+      live_uri = "http://localhost:4000/oauth/token"
+      {proof, _jkt} = Factory.dpop_proof(htu: live_uri)
+
+      assert {:ok, _} = DPoP.verify_proof(proof, base_opts(http_uri: live_uri))
+    end
+
+    test "an explicit http default port is equivalent to an omitted one at loopback" do
+      {proof, _jkt} = Factory.dpop_proof(htu: "http://localhost:80/oauth/token")
+
+      assert {:ok, _} =
+               DPoP.verify_proof(proof, base_opts(http_uri: "http://localhost/oauth/token"))
+    end
+
+    test "a loopback http htu never matches an https deployment (no downgrade)" do
+      {proof, _jkt} = Factory.dpop_proof(htu: "http://localhost/oauth/token")
+
+      assert {:error, :invalid_htu} =
+               DPoP.verify_proof(proof, base_opts(http_uri: "https://localhost/oauth/token"))
+    end
+
     test "rejects htu with other non-https schemes (ws://, file://, javascript:)" do
       for scheme <- ["ws://", "wss://", "file://", "javascript:"] do
         uri = scheme <> "api.example.com/oauth/token"

--- a/test/attesto/loopback_host_test.exs
+++ b/test/attesto/loopback_host_test.exs
@@ -1,0 +1,41 @@
+defmodule Attesto.LoopbackHostTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Attesto.LoopbackHost
+
+  describe "loopback?/1" do
+    test "accepts localhost, *.localhost (RFC 6761 §6.3), and is case-insensitive" do
+      assert LoopbackHost.loopback?("localhost")
+      assert LoopbackHost.loopback?("LOCALHOST")
+      assert LoopbackHost.loopback?("app.localhost")
+      assert LoopbackHost.loopback?("deep.sub.localhost")
+    end
+
+    test "accepts 127.0.0.0/8 dotted-quad literals (RFC 5735 §3)" do
+      assert LoopbackHost.loopback?("127.0.0.1")
+      assert LoopbackHost.loopback?("127.1.2.3")
+    end
+
+    test "accepts the IPv6 loopback, bracketed or bare" do
+      assert LoopbackHost.loopback?("::1")
+      assert LoopbackHost.loopback?("[::1]")
+    end
+
+    test "rejects any host that can name a remote peer" do
+      refute LoopbackHost.loopback?("api.example.com")
+      refute LoopbackHost.loopback?("localhost.example.com")
+      refute LoopbackHost.loopback?("mylocalhost")
+      refute LoopbackHost.loopback?("128.0.0.1")
+      refute LoopbackHost.loopback?("::2")
+    end
+
+    test "rejects non-dotted-quad 127/8 shorthands and non-binary input" do
+      # `:inet.parse_address/1` would admit "127.1"; the strict parser does not,
+      # so the carve-out stays limited to explicit dotted-quad literals.
+      refute LoopbackHost.loopback?("127.1")
+      refute LoopbackHost.loopback?(nil)
+      refute LoopbackHost.loopback?(:localhost)
+    end
+  end
+end

--- a/test/attesto/plug/oauth_error_test.exs
+++ b/test/attesto/plug/oauth_error_test.exs
@@ -98,6 +98,18 @@ defmodule Attesto.Plug.OAuthErrorTest do
                "expected no resource_metadata for #{inspect(bad)}"
       end
     end
+
+    test "a loopback http :resource_metadata is advertised (local development)" do
+      # The one admitted plain-http pointer: a loopback development resource,
+      # whose challenge would otherwise carry no discovery pointer at all.
+      url = "http://localhost:4000/.well-known/oauth-protected-resource/mcp"
+
+      conn =
+        conn(:get, "http://localhost:4000/mcp")
+        |> OAuthError.unauthorized(:bearer, "invalid_token", resource_metadata: url)
+
+      assert www_authenticate(conn) =~ ~s(resource_metadata="#{url}")
+    end
   end
 
   describe "insufficient_scope/2" do
@@ -242,12 +254,10 @@ defmodule Attesto.Plug.OAuthErrorTest do
     end
 
     test "a non-https resource_metadata is dropped on the 403 path (RFC 9728 §3)" do
-      # RFC 9728 requires an https metadata pointer; an http (incl. loopback) or
-      # malformed value is omitted rather than advertised. A host that needs an
-      # http loopback pointer in dev supplies the whole challenge via the
-      # `:www_authenticate` hook instead.
+      # RFC 9728 requires an https metadata pointer; a non-loopback http or
+      # malformed value is omitted rather than advertised. The loopback
+      # carve-out below is the local-development exception.
       for bad <- [
-            "http://localhost:9000/.well-known/oauth-protected-resource",
             "http://api.example.com/.well-known/oauth-protected-resource",
             "not-a-url"
           ] do
@@ -258,6 +268,16 @@ defmodule Attesto.Plug.OAuthErrorTest do
         refute www_authenticate(conn) =~ "resource_metadata",
                "expected no resource_metadata for #{inspect(bad)}"
       end
+    end
+
+    test "a loopback http resource_metadata is advertised on the 403 path (local development)" do
+      url = "http://localhost:9000/.well-known/oauth-protected-resource"
+
+      conn =
+        conn(:get, "http://localhost:9000/x")
+        |> OAuthError.insufficient_scope(["documents.read"], :bearer, resource_metadata: url)
+
+      assert www_authenticate(conn) =~ ~s(resource_metadata="#{url}")
     end
   end
 end

--- a/test/attesto/protected_resource_metadata_test.exs
+++ b/test/attesto/protected_resource_metadata_test.exs
@@ -62,6 +62,34 @@ defmodule Attesto.ProtectedResourceMetadataTest do
       end
     end
 
+    test "under require_https: false a loopback http resource renders (dev carve-out)" do
+      cfg =
+        config(
+          issuer: "http://localhost:4000",
+          audience: "http://localhost:4000/mcp",
+          require_https: false
+        )
+
+      assert PRM.metadata(cfg)["resource"] == "http://localhost:4000/mcp"
+
+      assert PRM.metadata(cfg, resource: "http://127.0.0.1:4000/mcp")["resource"] ==
+               "http://127.0.0.1:4000/mcp"
+    end
+
+    test "under require_https: false a NON-loopback http resource still fails fast" do
+      cfg = config(issuer: "http://localhost:4000", audience: "https://api.example.com/", require_https: false)
+
+      assert_raise ArgumentError, ~r/must be an absolute https URL/, fn ->
+        PRM.metadata(cfg, resource: "http://api.example.com/mcp")
+      end
+    end
+
+    test "under the default require_https: true a loopback http resource fails fast" do
+      assert_raise ArgumentError, ~r/must be an absolute https URL/, fn ->
+        PRM.metadata(config(), resource: "http://localhost:4000/mcp")
+      end
+    end
+
     test "every key is a string (JSON-serialisable shape)" do
       meta =
         PRM.metadata(config(),


### PR DESCRIPTION
## Summary

Developing an MCP resource server locally currently requires self-signed certificates or a TLS tunnel, because the https requirement is enforced unconditionally at config-build time — `issuer: "http://localhost:4000"` cannot boot. This PR adds a narrow, opt-in development carve-out:

- **`Attesto.Config` gains `require_https` (default `true`).** 
Setting `false` admits a plain-http issuer **only** when its host is loopback; a non-loopback http issuer is rejected regardless of the flag.
- **`Attesto.LoopbackHost`** — shared loopback detection: `localhost`, `*.localhost` (RFC 6761 §6.3), dotted-quad `127.0.0.0/8`, `::1`.
- **`ProtectedResourceMetadata`** now renders a loopback http resource under `require_https: false` — the behaviour the RFC 9728 comment in `resource/2` already promised, but the code still rejected.
- **`Plug.OAuthError`** advertises a loopback http `resource_metadata` pointer instead of dropping it (a dev resource otherwise emitted a challenge with no discovery pointer at all).
- **`DPoP`** accepts an http `htu` only at a loopback host, with default  port-80 normalization. No downgrade is possible: the scheme stays in  the compared tuple, so an http proof never matches an https deployment.

## Why loopback-only

Loopback traffic never leaves the machine, so TLS adds no transport security there — the same reasoning RFC 8252 §8.3 uses to exempt loopback redirect URIs, and the norm for MCP development tooling (`http://localhost` dev servers). Defaults are unchanged; production behaviour is unaffected unless a host explicitly opts out AND uses a loopback host.

## Testing

Full suite passes. New tests cover each carve-out and each rejection path (non-loopback http, default-flag http, DPoP downgrade).