### PR TITLE
Release 1.2.3 with advisory-safe Plug ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2026-07-16
+
+### Security
+
+- Constrain the optional Plug dependency to advisory-safe patch lines while
+  retaining compatibility across Plug 1.16 through 1.20. This prevents package
+  resolution from selecting affected releases between otherwise-safe lower and
+  upper bounds; Attesto's runtime behavior is unchanged.
+
 ## [1.2.2] - 2026-07-16
 
 ### Fixed

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.2.2"
+  @version "1.2.3"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 
@@ -57,7 +57,7 @@ defmodule Attesto.MixProject do
       {:jose, "~> 1.11"},
       # Optional: the Attesto.Plug.* integration layer. Hosts that use the
       # plugs already have Plug; the core library does not require it.
-      {:plug, ">= 1.19.5 and < 2.0.0", optional: true},
+      {:plug, "~> 1.16.6 or ~> 1.17.4 or ~> 1.18.5 or ~> 1.19.5 or >= 1.20.3 and < 2.0.0", optional: true},
 
       # test - cross-language parity / contract tests drive a reference
       # joserfc/cryptography stack in-process via the erlang_python `:py`


### PR DESCRIPTION
## Summary

- release Attesto 1.2.3 with the optional Plug dependency expressed as patched
  minor-line ranges
- retain compatibility across Plug 1.16 through 1.20 without allowing
  advisory-affected boundary releases
- document this package-metadata hardening in the changelog

## Verification

- Mix requirement parser matrix: 11 accepted fixed-line versions, 11 rejected
  boundary versions
- `mix format --check-formatted`
- `mix clean && mix compile --warnings-as-errors`
- `mix test` (1,487 passed: 67 properties, 1,420 tests)
- `mix credo --strict`
- `mix docs --warnings-as-errors`
- `mix hex.audit`
- `mix hex.build`

Closes #5
