### PR TITLE
Require advisory-fixed JOSE releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.4] - 2026-07-16
+
+### Security
+
+- Require JOSE 1.11.9 or later on the 1.11 release line. This excludes releases
+  affected by the PBES2 iteration-count denial of service and avoids the
+  unintended runtime Dialyxir dependency published in JOSE 1.11.7 and 1.11.8.
+
 ## [1.2.3] - 2026-07-16
 
 ### Security

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.2.3"
+  @version "1.2.4"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 
@@ -54,7 +54,7 @@ defmodule Attesto.MixProject do
 
   defp deps do
     [
-      {:jose, "~> 1.11"},
+      {:jose, "~> 1.11.9"},
       # Optional: the Attesto.Plug.* integration layer. Hosts that use the
       # plugs already have Plug; the core library does not require it.
       {:plug, "~> 1.16.6 or ~> 1.17.4 or ~> 1.18.5 or ~> 1.19.5 or >= 1.20.3 and < 2.0.0", optional: true},


### PR DESCRIPTION
## Summary

- require JOSE 1.11.9 or later on the supported 1.11 release line
- exclude releases affected by the PBES2 iteration-count denial of service
- avoid JOSE 1.11.7 and 1.11.8, whose package metadata adds Dialyxir at runtime

## Changes

Release Attesto 1.2.4 with a corrected JOSE dependency floor and document the security and package-metadata boundary.

Closes #7
