### PR TITLE
Require fully compatible JOSE 1.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.5] - 2026-07-17
+
+### Fixed
+
+- Require JOSE 1.11.12 or later on the 1.11 release line. JOSE 1.11.9 and
+  1.11.10 cannot encode or decode EC private keys on OTP 28 after OTP changed
+  the `ECPrivateKey` version representation. JOSE 1.11.11 fixed EC handling but
+  introduced a builtin-JSON regression that encoded Elixir `nil` as the string
+  `"nil"`; 1.11.12 is the first release to include both fixes. Attesto's public
+  API and runtime policy are unchanged.
+
 ## [1.2.4] - 2026-07-16
 
 ### Security

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.2.4"
+  @version "1.2.5"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 
@@ -54,7 +54,7 @@ defmodule Attesto.MixProject do
 
   defp deps do
     [
-      {:jose, "~> 1.11.9"},
+      {:jose, "~> 1.11.12"},
       # Optional: the Attesto.Plug.* integration layer. Hosts that use the
       # plugs already have Plug; the core library does not require it.
       {:plug, "~> 1.16.6 or ~> 1.17.4 or ~> 1.18.5 or ~> 1.19.5 or >= 1.20.3 and < 2.0.0", optional: true},

--- a/test/attesto/jose_compatibility_test.exs
+++ b/test/attesto/jose_compatibility_test.exs
@@ -1,0 +1,40 @@
+defmodule Attesto.JOSECompatibilityTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+
+  setup do
+    original_json_module = JOSE.json_module()
+    :ok = JOSE.json_module(:jose_json_otp)
+    on_exit(fn -> JOSE.json_module(original_json_module) end)
+  end
+
+  test "EC keys export and import through a public JWK before ES256 verification" do
+    private_key = JOSE.JWK.generate_key({:ec, "P-256"})
+    {_, public_map} = JOSE.JWK.to_public_map(private_key)
+    public_key = JOSE.JWK.from_map(public_map)
+    payload = ~s({"sub":"minimum-version-consumer"})
+
+    {_, compact} =
+      private_key
+      |> JOSE.JWS.sign(payload, %{"alg" => "ES256", "typ" => "JWT"})
+      |> JOSE.JWS.compact()
+
+    assert %{"crv" => "P-256", "kty" => "EC", "x" => _x, "y" => _y} = public_map
+    refute Map.has_key?(public_map, "d")
+    assert {true, ^payload, _verified_jws} = JOSE.JWS.verify_strict(public_key, ["ES256"], compact)
+  end
+
+  test "the builtin OTP JSON backend encodes an Elixir nil JWT claim as null" do
+    private_key = JOSE.JWK.generate_key({:ec, "P-256"})
+
+    {_, compact} =
+      private_key
+      |> JOSE.JWT.sign(%{"alg" => "ES256"}, %{"optional" => nil, "sub" => "json-consumer"})
+      |> JOSE.JWS.compact()
+
+    [_header, encoded_payload, _signature] = String.split(compact, ".")
+    payload = encoded_payload |> Base.url_decode64!(padding: false) |> JSON.decode!()
+
+    assert payload == %{"optional" => nil, "sub" => "json-consumer"}
+  end
+end


### PR DESCRIPTION
## Summary

- require JOSE 1.11.12 or later on the supported 1.11 release line
- release Attesto 1.2.5 with both compatibility boundaries documented and tested

## Changes

JOSE 1.11.9 and 1.11.10 expect the pre-OTP-28 integer representation of the `ECPrivateKey` version field, so EC key export and import can fail on OTP 28. JOSE 1.11.11 fixed EC handling but introduced a separate builtin-JSON regression that encoded Elixir `nil` as the string `"nil"`; JOSE 1.11.12 is the first release containing both fixes.

Focused regressions cover EC public-JWK export/import with ES256 verification and builtin OTP JSON `nil`-to-`null` encoding. The lock already selects JOSE 1.11.12, so every supported OTP 27, 28, and 29 CI job exercises the exact dependency floor. Attesto's public API and runtime policy are unchanged.

Closes #9
