### PR TITLE
Correct trusted token algorithm documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- Correct the token, ID Token, logout-token, and keystore documentation to
+  describe Attesto's existing multi-algorithm support. Signing and verification
+  bind RS256, PS256, ES256, ES384, ES512, or EdDSA to trusted keystore metadata
+  or the key type and curve; verification never learns algorithm policy from a
+  presented JWS header. Runtime behavior is unchanged.
+
 ## [1.2.5] - 2026-07-17
 
 ### Fixed

--- a/lib/attesto.ex
+++ b/lib/attesto.ex
@@ -5,10 +5,10 @@ defmodule Attesto do
 
   Attesto implements the parts of OAuth/OIDC that are the same for every
   deployment and easy to get subtly wrong - JWT signing and verification
-  with a pinned algorithm and `kid`-based key selection, sender-constrained
-  tokens via DPoP (RFC 9449) and mutual-TLS (RFC 8705), PKCE (RFC 7636),
-  and the scope grant-form algebra. It deliberately does **not** implement
-  your identity model, persistence, or authorization policy.
+  with a trusted, key-bound algorithm and `kid`-based key selection,
+  sender-constrained tokens via DPoP (RFC 9449) and mutual-TLS (RFC 8705),
+  PKCE (RFC 7636), and the scope grant-form algebra. It deliberately does
+  **not** implement your identity model, persistence, or authorization policy.
 
   ## The split
 

--- a/lib/attesto/id_token.ex
+++ b/lib/attesto/id_token.ex
@@ -11,10 +11,13 @@ defmodule Attesto.IDToken do
   kept in separate modules rather than overloading one mint path.
 
   Like `Attesto.Token`, the operations are pure: they read only the
-  `Attesto.Config` passed in. Signing uses the same keystore/`kid` path
-  and the same RS256 pinning, and every JOSE call funnels through
-  `JOSE.JWS` / `JOSE.JWT.verify_strict` so the alg whitelist (no `none`,
-  no `HS256` confusion) lives in one place and fails closed.
+  `Attesto.Config` passed in. Signing uses the same keystore/`kid` path and
+  trusted, key-bound algorithm resolution: RS256, PS256, ES256, ES384, ES512,
+  or EdDSA as selected by `Attesto.SigningAlg`. Verification derives each
+  candidate key's accepted algorithm from per-key keystore metadata or the
+  key type and curve rather than the presented header, then calls
+  `JOSE.JWT.verify_strict` with that singleton allowlist. `none`, `HS*`, and
+  any asymmetric algorithm not bound to the trusted key fail closed.
 
   ## Claims (OpenID Connect Core §2)
 
@@ -63,9 +66,9 @@ defmodule Attesto.IDToken do
 
   `at_hash` and `c_hash` use the same construction (OIDC Core §3.1.3.6,
   §3.3.2.11): hash the ASCII octets of the `access_token` / `code` with
-  the hash of the ID Token's signature algorithm (SHA-256 for RS256),
-  take the left-most half of the digest, and base64url-encode it without
-  padding.
+  the hash associated with the ID Token's signature algorithm (for example,
+  SHA-256 for RS256), take the left-most half of the digest, and
+  base64url-encode it without padding.
   """
 
   alias Attesto.Config
@@ -210,15 +213,17 @@ defmodule Attesto.IDToken do
   in order:
 
     1. **Signature.** The compact JWS is canonical - three base64url-no-pad
-       segments - and its RS256 signature verifies against a keystore key
-       selected by the JWS header `kid`. A `kid` naming a key we do not
-       hold, or an `alg` other than RS256, fails as `:invalid_signature`
-       (alg-confusion is impossible). A protected header carrying a `crit`
-       parameter (RFC 7515 §4.1.11) is rejected with
+       segments - and its signature verifies against a keystore key selected
+       by the JWS header `kid`. Each candidate key's accepted algorithm comes
+       from trusted keystore metadata or the key type/curve, never from the
+       presented header. A `kid` naming a key we do not hold, or an `alg` that
+       does not exactly match the algorithm bound to that key, fails as
+       `:invalid_signature` (alg-confusion is impossible). A protected header
+       carrying a `crit` parameter (RFC 7515 §4.1.11) is rejected with
        `:unsupported_critical_header`. The JOSE header `typ`, when present,
        MUST be `"JWT"`; an access-token header such as `"at+jwt"` is
-       `:unexpected_typ`. Verification also rejects access-token-only
-       payload claims such as `scope`, `typ: "access"`, and the configured
+       `:unexpected_typ`. Verification also rejects access-token-only payload
+       claims such as `scope`, `typ: "access"`, and the configured
        principal-kind claim, so token-type separation does not depend solely
        on the optional JOSE `typ` header.
     2. **`iss`** equals the configured issuer (OIDC Core §3.1.3.7 item 1).
@@ -369,7 +374,7 @@ defmodule Attesto.IDToken do
 
   # Mirrors `Attesto.Token`'s signature path: peek the protected header,
   # reject any `crit` member (RFC 7515 §4.1.11), select keystore keys by
-  # `kid`, and verify strictly against the RS256 whitelist.
+  # `kid`, and verify strictly against each trusted key's bound algorithm.
   defp verify_signature(config, jwt) do
     with :ok <- check_compact_form(jwt),
          {:ok, header} <- peek_protected_header(jwt),
@@ -447,8 +452,9 @@ defmodule Attesto.IDToken do
         {:ok, claims}
 
       {false, _jwt_struct, _jws_struct} ->
-        # Covers signature-tamper and alg-confusion: the whitelist forces
-        # any non-RS256 header to verified? == false.
+        # Covers signature-tamper and alg-confusion: the singleton whitelist
+        # forces any header algorithm other than this trusted key's bound
+        # algorithm to verified? == false.
         {:error, :invalid_signature}
 
       _other ->

--- a/lib/attesto/keystore.ex
+++ b/lib/attesto/keystore.ex
@@ -26,7 +26,10 @@ defmodule Attesto.Keystore do
   """
 
   @doc """
-  The private RSA key PEM used to sign newly issued tokens.
+  The private signing-key PEM used to sign newly issued tokens.
+
+  The key must support one of the asymmetric algorithms accepted by
+  `Attesto.SigningAlg`.
   """
   @callback signing_pem() :: String.t()
 
@@ -51,8 +54,11 @@ defmodule Attesto.Keystore do
   Optional global algorithm for the current signing key.
 
   This is a convenience for single-key RSA deployments that want PS256
-  without precomputing the signing key's `kid`. Verification still uses
-  `key_algs/0` when present, then key inference.
+  without precomputing the signing key's `kid`. A custom keystore whose value
+  differs from key inference MUST expose the same binding through `key_algs/0`
+  so its newly minted tokens also verify. `Attesto.Keystore.Static` does that
+  automatically. Verification otherwise uses `key_algs/0` when present, then
+  key inference.
   """
   @callback signing_alg() :: String.t()
 

--- a/lib/attesto/logout_token.ex
+++ b/lib/attesto/logout_token.ex
@@ -12,9 +12,11 @@ defmodule Attesto.LogoutToken do
   or authorization claims.
 
   Like `Attesto.IDToken`, minting is pure: it reads only the `Attesto.Config`
-  passed in, signs through the same keystore/`kid`/RS256 path, and funnels the
-  JOSE call through the shared internal JWS signer so the alg whitelist lives in
-  one place.
+  passed in and signs through the same keystore/`kid` path. The algorithm is
+  bound to trusted keystore metadata or the signing key's type and curve by
+  `Attesto.SigningAlg`; the protected header records that resolved algorithm
+  but never supplies its policy. The JOSE call funnels through the shared
+  internal JWS signer.
 
   ## Claims (Back-Channel Logout 1.0 §2.4)
 

--- a/lib/attesto/token.ex
+++ b/lib/attesto/token.ex
@@ -1,6 +1,6 @@
 defmodule Attesto.Token do
   @moduledoc """
-  Mint and verify RS256 JWT access tokens.
+  Mint and verify JWT access tokens with trusted, key-bound algorithms.
 
   This is the heart of the engine: a single mint point and a single
   verifier that one issuer uses for every kind of principal. The two
@@ -30,10 +30,22 @@ defmodule Attesto.Token do
     * any per-kind required claims (e.g. `client_id`).
     * `cnf` - present iff the token is sender-constrained (DPoP or mTLS).
 
-  Tokens are signed RS256 with the key the configured `Attesto.Keystore`
-  provides; the JWS header carries the key's `kid` (its RFC 7638
-  thumbprint). The algorithm is pinned: `verify/3` rejects anything but
-  RS256, so `none`/`HS256` alg-confusion is impossible by construction.
+  Tokens are signed with the key the configured `Attesto.Keystore` provides;
+  the JWS header carries the key's `kid` (its RFC 7638 thumbprint) and the
+  algorithm resolved by `Attesto.SigningAlg`. Minting resolves that algorithm
+  from per-key `key_algs/0` metadata, then `signing_alg/0` for the current
+  signing key, then the trusted key type and curve. The supported set is
+  RS256, PS256, ES256, ES384, ES512, and EdDSA; RSA defaults to RS256.
+
+  Verification never learns algorithm policy from the presented JWS header.
+  The header `kid` only narrows the configured verification-key set; each
+  candidate key's permitted algorithm is resolved independently from per-key
+  `key_algs/0` metadata or the key type and curve, then passed as a singleton
+  allowlist to JOSE's strict verifier. `Attesto.Keystore.Static` mirrors an
+  explicitly configured `signing_alg` onto the current key's `kid`, so its
+  mint and verification policies agree without weakening that binding. A
+  token carrying `none`, an `HS*` algorithm, or any asymmetric algorithm other
+  than the one bound to that trusted key fails as `:invalid_signature`.
 
   ## Sender constraints
 
@@ -244,14 +256,16 @@ defmodule Attesto.Token do
     1. **Signature.** The compact JWS is canonical - three base64url-no-pad
        segments (Attesto rejects `=` padding or any non-base64url byte at
        its boundary, refusing to verify a serialization the issuer never
-       emitted) - and its RS256 signature
-       verifies against a key the keystore trusts, selected by the JWS
-       header `kid`. A token whose `kid` names a key we do not hold, or
-       whose header `alg` is anything but RS256, fails as
-       `:invalid_signature` (alg-confusion is impossible). A token whose
-       protected header carries a `crit` parameter (RFC 7515 §4.1.11) is
-       rejected with `:unsupported_critical_header` - Attesto implements no
-       JWS extensions, so it must not honour a token that demands one.
+       emitted) - and its signature verifies against a key the keystore
+       trusts, selected by the JWS header `kid`. The accepted algorithm for
+       each candidate key comes from trusted keystore metadata or the key
+       type/curve, never from the presented header. A token whose `kid` names
+       a key we do not hold, or whose header `alg` does not exactly match the
+       algorithm bound to that key, fails as `:invalid_signature`
+       (alg-confusion is impossible). A token whose protected header carries
+       a `crit` parameter (RFC 7515 §4.1.11) is rejected with
+       `:unsupported_critical_header` - Attesto implements no JWS extensions,
+       so it must not honour a token that demands one.
     2. **Confirmation shape.** If a `cnf` is present it MUST be exactly
        `%{"jkt" => <thumbprint>}` (DPoP) or `%{"x5t#S256" => <thumbprint>}`
        (mTLS), with a canonical thumbprint and no other members; anything
@@ -350,9 +364,9 @@ defmodule Attesto.Token do
   end
 
   @doc """
-  Return a token's claims iff its RS256 signature verifies against a
-  keystore key. Skips every other check (`iss`, `aud`, `exp`, claim
-  shape, binding).
+  Return a token's claims iff its signature verifies against a keystore key
+  under that trusted key's configured or derived algorithm. Skips every other
+  check (`iss`, `aud`, `exp`, claim shape, binding).
 
   This is NOT an authentication primitive - the token may be expired,
   replayed, wrongly scoped, or bound to a key the request did not present.
@@ -656,9 +670,9 @@ defmodule Attesto.Token do
         {:ok, claims}
 
       {false, _jwt_struct, _jws_struct} ->
-        # Covers signature-tamper and alg-confusion: the whitelist passed
-        # to verify_strict forces any non-RS256 header here with
-        # verified? == false.
+        # Covers signature-tamper and alg-confusion: the singleton whitelist
+        # passed to verify_strict forces any header algorithm other than the
+        # one bound to this trusted candidate key to verified? == false.
         {:error, :invalid_signature}
 
       _other ->

--- a/test/attesto/conformance_vectors_test.exs
+++ b/test/attesto/conformance_vectors_test.exs
@@ -174,7 +174,7 @@ defmodule Attesto.ConformanceVectorsTest do
       jwk = JOSE.JWK.from_map(@rfc7515_public_jwk)
 
       # Pin the algorithm explicitly: verify_strict rejects any alg other
-      # than RS256, exactly as Attesto.Token does (alg-confusion proof).
+      # than RS256, as Attesto.Token does for a key resolved to RS256.
       assert {true, %JOSE.JWT{}, %JOSE.JWS{}} =
                JOSE.JWT.verify_strict(jwk, ["RS256"], @rfc7515_jws)
     end

--- a/test/attesto/id_token_test.exs
+++ b/test/attesto/id_token_test.exs
@@ -52,7 +52,7 @@ defmodule Attesto.IDTokenTest do
       refute Map.has_key?(payload!(jwt), "scope")
     end
 
-    test "the JOSE header is RS256/kid and typ JWT, never at+jwt", %{config: config, pem: pem} do
+    test "the default RSA JOSE header is RS256/kid and typ JWT, never at+jwt", %{config: config, pem: pem} do
       assert {:ok, jwt} = IDToken.mint(config, @subject, @client_id)
 
       header = header!(jwt)
@@ -163,6 +163,35 @@ defmodule Attesto.IDTokenTest do
       dt = ~U[2026-01-01 00:00:00Z]
       assert {:ok, jwt} = IDToken.mint(config, @subject, @client_id, now: dt)
       assert payload!(jwt)["iat"] == DateTime.to_unix(dt, :second)
+    end
+  end
+
+  describe "trusted key-bound signing algorithms" do
+    for {alg, key} <- [
+          {"RS256", :rsa},
+          {"PS256", :rsa},
+          {"ES256", {:ec, "P-256"}},
+          {"ES384", {:ec, "P-384"}},
+          {"ES512", {:ec, "P-521"}},
+          {"EdDSA", :ed25519}
+        ] do
+      test "#{alg} mint and verify agree" do
+        alg = unquote(alg)
+        pem = signing_pem(unquote(Macro.escape(key)))
+        config_opts = if alg == "PS256", do: [signing_alg: alg], else: []
+        config = Factory.config(pem, config_opts)
+
+        assert {:ok, jwt} = IDToken.mint(config, @subject, @client_id)
+
+        assert header!(jwt) == %{
+                 "alg" => alg,
+                 "kid" => Key.kid(pem),
+                 "typ" => "JWT"
+               }
+
+        assert {:ok, claims} = IDToken.verify(config, jwt, client_id: @client_id)
+        assert claims["sub"] == @subject
+      end
     end
   end
 
@@ -482,4 +511,8 @@ defmodule Attesto.IDTokenTest do
     {_, jwt} = jwk |> JOSE.JWS.sign(JSON.encode!(claims), header) |> JOSE.JWS.compact()
     jwt
   end
+
+  defp signing_pem(:rsa), do: Factory.rsa_pem()
+  defp signing_pem({:ec, curve}), do: Factory.ec_pem(curve)
+  defp signing_pem(:ed25519), do: Factory.ed_pem()
 end

--- a/test/attesto/logout_token_test.exs
+++ b/test/attesto/logout_token_test.exs
@@ -48,7 +48,7 @@ defmodule Attesto.LogoutTokenTest do
       assert claims["events"] == %{@event_uri => %{}}
     end
 
-    test "the JOSE header typ is logout+jwt, RS256/kid", %{config: config, pem: pem} do
+    test "the default RSA JOSE header is logout+jwt with RS256/kid", %{config: config, pem: pem} do
       assert {:ok, jwt} = LogoutToken.mint(config, @client_id, sub: @subject)
       header = header!(jwt)
       assert header["typ"] == "logout+jwt"

--- a/test/attesto/security_negative_test.exs
+++ b/test/attesto/security_negative_test.exs
@@ -158,8 +158,8 @@ defmodule Attesto.SecurityNegativeTest do
     test "an HS256 token (symmetric, signed with the RSA public PEM as the secret) is rejected",
          %{config: config, pem: pem} do
       # The classic RS256->HS256 confusion: an attacker who knows the public
-      # key signs an HMAC with the public PEM bytes as the secret. Token pins
-      # RS256, so verify_strict's allow-list forces verified? == false.
+      # key signs an HMAC with the public PEM bytes as the secret. This trusted
+      # RSA key resolves to RS256, so verify_strict rejects the header.
       public_pem = Key.public_pem(pem)
       secret = JOSE.JWK.from_oct(public_pem)
 
@@ -206,10 +206,11 @@ defmodule Attesto.SecurityNegativeTest do
     end
 
     # RFC 7515 §4.1.11: a recipient that does not understand a parameter
-    # named in `crit` MUST reject the JWS. attesto pins RS256 and understands
-    # no extension parameters, so any `crit` member is rejected with
-    # `:unsupported_critical_header` (JOSE itself does no `crit` processing,
-    # so attesto enforces this in `verify/3` before trusting the token).
+    # named in `crit` MUST reject the JWS. This fixture's trusted key resolves
+    # to RS256 and Attesto understands no extension parameters, so `crit` is
+    # rejected with `:unsupported_critical_header` (JOSE itself does no `crit`
+    # processing, so Attesto enforces this in `verify/3` before trusting the
+    # token).
     test "a token whose protected header carries an unknown `crit` parameter is rejected",
          %{config: config, pem: pem} do
       jwt =

--- a/test/attesto/token_at_jwt_test.exs
+++ b/test/attesto/token_at_jwt_test.exs
@@ -42,7 +42,7 @@ defmodule Attesto.TokenAtJwtTest do
       assert header["typ"] == "at+jwt"
     end
 
-    test "alg is RS256 and kid is present on every access token", %{pem: pem} do
+    test "the default RSA algorithm and kid are present on an access token", %{pem: pem} do
       config = Factory.config(pem)
 
       assert {:ok, %{access_token: jwt}} = Token.mint(config, client_principal())
@@ -78,23 +78,50 @@ defmodule Attesto.TokenAtJwtTest do
     end
   end
 
-  describe "non-RSA signing key" do
-    test "minting with an EC P-256 signing key uses ES256 and verifies" do
-      ec_pem =
-        {:ec, "P-256"}
-        |> JOSE.JWK.generate_key()
-        |> JOSE.JWK.to_pem()
-        |> elem(1)
+  describe "trusted key-bound signing algorithms" do
+    for {alg, key} <- [
+          {"RS256", :rsa},
+          {"PS256", :rsa},
+          {"ES256", {:ec, "P-256"}},
+          {"ES384", {:ec, "P-384"}},
+          {"ES512", {:ec, "P-521"}},
+          {"EdDSA", :ed25519}
+        ] do
+      test "#{alg} mint, verify, and signed-claims inspection agree" do
+        alg = unquote(alg)
+        pem = signing_pem(unquote(Macro.escape(key)))
+        config_opts = if alg == "PS256", do: [signing_alg: alg], else: []
+        config = Factory.config(pem, config_opts)
 
-      config = Factory.config(ec_pem)
+        assert {:ok, %{access_token: jwt}} = Token.mint(config, client_principal())
 
-      assert {:ok, %{access_token: jwt}} = Token.mint(config, client_principal())
+        assert %{"alg" => ^alg, "kid" => kid} = protected_header(jwt)
+        assert kid == Attesto.Key.kid(pem)
 
-      header = protected_header(jwt)
-      assert header["alg"] == "ES256"
-      assert header["kid"] == Attesto.Key.kid(ec_pem)
-      assert {:ok, claims} = Token.verify(config, jwt)
-      assert claims["sub"] == "oc_abc123"
+        assert {:ok, claims} = Token.verify(config, jwt)
+        assert claims["sub"] == "oc_abc123"
+
+        assert {:ok, signed_claims} = Token.peek_signed_claims(config, jwt)
+        assert signed_claims == claims
+      end
+    end
+
+    test "verification does not learn algorithm policy from a valid token header" do
+      pem = Factory.rsa_pem()
+      rs256_config = Factory.config(pem)
+
+      assert {:ok, %{access_token: jwt}} = Token.mint(rs256_config, client_principal())
+
+      assert protected_header(jwt) == %{
+               "alg" => "RS256",
+               "kid" => Attesto.Key.kid(pem),
+               "typ" => "at+jwt"
+             }
+
+      ps256_config = Factory.config(pem, signing_alg: "PS256")
+
+      assert {:error, :invalid_signature} = Token.verify(ps256_config, jwt)
+      assert {:error, :invalid_signature} = Token.peek_signed_claims(ps256_config, jwt)
     end
   end
 
@@ -123,4 +150,8 @@ defmodule Attesto.TokenAtJwtTest do
       refute Map.has_key?(header, "typ")
     end
   end
+
+  defp signing_pem(:rsa), do: Factory.rsa_pem()
+  defp signing_pem({:ec, curve}), do: Factory.ec_pem(curve)
+  defp signing_pem(:ed25519), do: Factory.ed_pem()
 end

--- a/test/attesto/token_mint_test.exs
+++ b/test/attesto/token_mint_test.exs
@@ -86,7 +86,7 @@ defmodule Attesto.TokenMintTest do
       assert length(Enum.uniq(jtis)) == 20
     end
 
-    test "the JWS header pins alg=RS256 and carries the signing key kid", %{config: config, pem: pem} do
+    test "the default RSA JWS header carries alg=RS256 and the signing key kid", %{config: config, pem: pem} do
       assert {:ok, %{access_token: jwt}} = Token.mint(config, client_principal())
 
       header = header!(jwt)

--- a/test/attesto/token_temporal_test.exs
+++ b/test/attesto/token_temporal_test.exs
@@ -1,7 +1,7 @@
 defmodule Attesto.TokenTemporalTest do
   @moduledoc false
   # Temporal and audience edge cases for Attesto.Token.verify/3, exercised
-  # by forging RS256-signed tokens with arbitrary claims.
+  # by forging tokens with the fixture's trusted RS256 key and arbitrary claims.
   #
   # Each case mints a baseline valid token via Token.mint, decodes its
   # claims, overrides ONLY the claim under test, and re-signs with the same
@@ -48,9 +48,9 @@ defmodule Attesto.TokenTemporalTest do
     payload |> Base.url_decode64!(padding: false) |> JSON.decode!()
   end
 
-  # Re-sign `claims` with the config's keystore key the way Token.sign/2
-  # does: RS256 over the key's kid. The signature is genuine, so verify can
-  # only fail on the claim content.
+  # Re-sign `claims` with the config's keystore key the way Token.sign/2 does
+  # for this default RSA fixture: RS256 over the key's kid. The signature is
+  # genuine, so verify can only fail on the claim content.
   defp resign(pem, claims) do
     jwk = Key.signing_jwk(pem)
 

--- a/test/attesto/token_verify_test.exs
+++ b/test/attesto/token_verify_test.exs
@@ -23,7 +23,7 @@ defmodule Attesto.TokenVerifyTest do
   defp unix_in(delta) when is_integer(delta), do: unix_now() + delta
 
   # Sign an arbitrary claim map with `pem` so the signature is structurally
-  # valid, the way Attesto.Token.sign/2 does (RS256 + the key's kid). The
+  # valid under Attesto.Token's default RSA path (RS256 + the key's kid). The
   # mandatory `principal_kind` and `typ` claims default so claim-rejection
   # tests that do not care about them exercise an otherwise valid token; a
   # claim may be forced ABSENT with the :__drop__ sentinel.

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Attesto.Test.Factory do
 
   alias Attesto.Keystore.Static
 
-  @doc "A fresh PKCS#1 RSA private-key PEM (the shape Attesto.Key expects)."
+  @doc "A fresh PKCS#1 RSA private-key PEM for default-RSA fixtures."
   def rsa_pem(bits \\ 2048) do
     priv = :public_key.generate_key({:rsa, bits, 65_537})
     :public_key.pem_encode([:public_key.pem_entry_encode(:RSAPrivateKey, priv)])


### PR DESCRIPTION
## Summary

- Correct token, ID Token, logout-token, and keystore documentation to describe the existing trusted, key-bound algorithm support.
- Expand regression coverage for the documented multi-algorithm behavior without changing runtime behavior.

## Changes

The previous documentation described token handling as RS256-only even though `Attesto.SigningAlg` already supports RS256, PS256, ES256, ES384, ES512, and EdDSA. This clarifies that verification resolves each accepted algorithm from trusted keystore metadata or key material rather than from the presented JWS header.

Fixes #12
