### PR TITLE
Correct Edwards OIDC hash claims and FAPI key policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,49 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-07-25
+
+### Changed
+
+- Admit compatible JOSE releases through the 1.x line while retaining 1.11.12
+  as the minimum security- and runtime-compatible version. This lets hosts use
+  newer native cryptographic adapters without another Attesto release.
+
+### Fixed
+
+- Derive OIDC `at_hash` and `c_hash` claims for Ed25519-signed ID Tokens with
+  SHA-512 and Ed448-signed ID Tokens with SHAKE256, matching their signature
+  primitives and interoperable OIDC validators. Previously EdDSA used SHA-256
+  unconditionally, contrary to OIDC's generic hash rule when applied to RFC
+  8032. ID Token and logout-token minting now snapshot the signing PEM once so
+  algorithm, curve-specific hash, `kid`, and signature cannot straddle a
+  keystore rotation. Algorithm selection remains bound to trusted keystore
+  metadata and key material; Ed448 uses JOSE's configured Curve448 and SHA3
+  backends. The ambiguous keyless `hash_alg/1` and `hash_half_bytes/1` helpers
+  remain Ed25519-compatible but are deprecated in favor of key-aware
+  `oidc_hash_profile/2` and `oidc_hash/3`. A missing SHAKE256 backend now raises
+  a direct configuration error.
+- Support RFC 9864's exact `Ed25519` and `Ed448` JOSE identifiers in trusted
+  key metadata, signing, verification, ID Token hash profiles, and DPoP while
+  retaining legacy `EdDSA` inference for wire compatibility. DPoP discovery
+  advertises the new identifiers only when the configured JOSE backend reports
+  them available. Default FAPI client-assertion, signed-request-object, and
+  CIBA policies accept EdDSA only over a trusted Ed25519 key and accept exact
+  Ed25519, never Ed448, and require PS256 RSA moduli to be at least 2048 bits;
+  an explicit non-FAPI allowlist can opt into Ed448 or a weaker RSA key, while
+  named FAPI policies retain the key gate when their algorithm list is
+  narrowed. DPoP rejects RSA proof keys with moduli below 2048 bits for every
+  accepted RSASSA and RSA-PSS proof algorithm. FAPI server keystores must also
+  provision RSA keys of at least 2048 bits; generic keystore resolution remains
+  profile-neutral for backward compatibility.
 
 ### Documentation
 
 - Correct the token, ID Token, logout-token, and keystore documentation to
   describe Attesto's existing multi-algorithm support. Signing and verification
-  bind RS256, PS256, ES256, ES384, ES512, or EdDSA to trusted keystore metadata
-  or the key type and curve; verification never learns algorithm policy from a
-  presented JWS header. Runtime behavior is unchanged.
+  bind RS256, PS256, ES256, ES384, ES512, legacy EdDSA, Ed25519, or Ed448 to
+  trusted keystore metadata or the key type and curve; verification never
+  learns algorithm policy from a presented JWS header.
 
 ## [1.2.5] - 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ token, DPoP, and scope checks as Plug modules and adds the MCP-facing
 ```elixir
 def deps do
   [
-    {:attesto, "~> 1.2"}
+    {:attesto, "~> 1.3"}
   ]
 end
 ```
@@ -373,7 +373,7 @@ constraint.
 
 ## Status
 
-A stable `1.x` release: the public API follows [semantic versioning](https://semver.org/) — minor and patch releases are backward-compatible and breaking changes wait for a new major version (read the CHANGELOG before upgrading). Implemented and tested: token issue/verify, DPoP, mTLS certificate-bound tokens, scope, keystore, PKCE validation, JWKS publication, OIDC discovery, the authorization-code grant (single-use, optionally DPoP-bound), refresh-token rotation with reuse detection, token revocation (RFC 7009, refresh-token family), Pushed Authorization Request primitives (RFC 9126), Resource Indicators (RFC 8707), signed request-object policy (JAR) and JARM response signing, token introspection and signed introspection response JWTs, Step-Up Authentication challenges (RFC 9470), the JWT-assertion (`jwt-bearer`) grant, the Device Authorization Grant (RFC 8628), Client-Initiated Backchannel Authentication (CIBA; poll/ping, signed requests per FAPI-CIBA), the RP-Initiated / Back-Channel / Front-Channel Logout and Session Management primitives, RFC 9728 protected-resource metadata, and Client ID Metadata Document (CIMD) verification. The stateful grants run against the `Attesto.CodeStore` / `Attesto.RefreshStore` behaviours, with ETS reference implementations included; a production host implements those over its own database (the atomic-`take` and atomic-`consume` contracts are documented). Cross-language parity tests check Attesto-issued artifacts against a reference implementation in another language. Pin to `~> 1.2`.
+A stable `1.x` release: the public API follows [semantic versioning](https://semver.org/) — minor and patch releases are backward-compatible and breaking changes wait for a new major version (read the CHANGELOG before upgrading). Implemented and tested: token issue/verify, DPoP, mTLS certificate-bound tokens, scope, keystore, PKCE validation, JWKS publication, OIDC discovery, the authorization-code grant (single-use, optionally DPoP-bound), refresh-token rotation with reuse detection, token revocation (RFC 7009, refresh-token family), Pushed Authorization Request primitives (RFC 9126), Resource Indicators (RFC 8707), signed request-object policy (JAR) and JARM response signing, token introspection and signed introspection response JWTs, Step-Up Authentication challenges (RFC 9470), the JWT-assertion (`jwt-bearer`) grant, the Device Authorization Grant (RFC 8628), Client-Initiated Backchannel Authentication (CIBA; poll/ping, signed requests per FAPI-CIBA), the RP-Initiated / Back-Channel / Front-Channel Logout and Session Management primitives, RFC 9728 protected-resource metadata, and Client ID Metadata Document (CIMD) verification. The stateful grants run against the `Attesto.CodeStore` / `Attesto.RefreshStore` behaviours, with ETS reference implementations included; a production host implements those over its own database (the atomic-`take` and atomic-`consume` contracts are documented). Cross-language parity tests check Attesto-issued artifacts against a reference implementation in another language. Pin to `~> 1.3`.
 
 ## Development
 

--- a/lib/attesto/ciba/request.ex
+++ b/lib/attesto/ciba/request.ex
@@ -159,10 +159,17 @@ defmodule Attesto.CIBA.Request do
     * `:require_signed_request` - when `true`, reject a plain-parameter
       request (FAPI-CIBA §5.2.2 requires signed requests). Default `false`.
     * `:accepted_algs` - JOSE algorithms acceptable for signed requests.
-      Defaults to `Attesto.SigningAlg.default_client_algs/0`; a FAPI-CIBA
-      deployment narrows this to `["PS256", "ES256"]`. The client's registered
-      `:request_signing_alg`, when set, must be inside this set and becomes
-      the only accepted algorithm.
+      Defaults to `Attesto.SigningAlg.default_client_algs/0`, including legacy
+      EdDSA only over Ed25519 and RFC 9864 Ed25519, never Ed448. Supplying a
+      list selects an explicit non-FAPI algorithm policy unless
+      `:enforce_fapi_alg_policy` is also `true`. The client's registered
+      `:request_signing_alg`, when set, must be inside this set and becomes the
+      only accepted algorithm.
+    * `:enforce_fapi_alg_policy` - enforce the FAPI RSA modulus and Edwards
+      curve restrictions in addition to `:accepted_algs`. Defaults to `true`
+      when `:accepted_algs` is omitted and `false` when the caller supplies an
+      explicit algorithm policy. Composed FAPI profiles that narrow the
+      allowlist must pass `true`.
     * `:max_request_lifetime_seconds` - bound on a signed request's
       `nbf`→`exp` lifetime. Default `#{@default_max_request_lifetime_seconds}`
       (FAPI-CIBA §5.2.2's 60 minutes).
@@ -281,6 +288,8 @@ defmodule Attesto.CIBA.Request do
         # §7.1.1: `aud` MUST contain the OP's Issuer Identifier.
         audience: issuer,
         accepted_algs: algs,
+        enforce_fapi_alg_policy:
+          Keyword.get(opts, :enforce_fapi_alg_policy, not Keyword.has_key?(opts, :accepted_algs)),
         # §7.1.1 makes exp, iat, nbf, and jti all REQUIRED.
         require_exp: true,
         require_iat: true,

--- a/lib/attesto/client_assertion.ex
+++ b/lib/attesto/client_assertion.ex
@@ -26,6 +26,7 @@ defmodule Attesto.ClientAssertion do
           {:now, DateTime.t() | non_neg_integer()}
           | {:max_lifetime, pos_integer()}
           | {:accepted_algs, [SigningAlg.alg()]}
+          | {:enforce_fapi_alg_policy, boolean()}
         ]
 
   @type verify_error ::
@@ -65,8 +66,14 @@ defmodule Attesto.ClientAssertion do
   Opts:
 
     * `:accepted_algs` - the JOSE algorithms a candidate trusted key may use.
-      Defaults to `SigningAlg.fapi_algs/0` (PS256, ES256, EdDSA), keeping the
-      FAPI 2 client-authentication gate. A non-FAPI profile can widen this.
+      Defaults to `SigningAlg.fapi_algs/0` (PS256, ES256, EdDSA over Ed25519,
+      and explicit Ed25519). Supplying a list selects an explicit non-FAPI
+      algorithm policy unless `:enforce_fapi_alg_policy` is also `true`.
+    * `:enforce_fapi_alg_policy` - enforce the FAPI RSA modulus and Edwards
+      curve restrictions in addition to `:accepted_algs`. Defaults to `true`
+      when `:accepted_algs` is omitted and `false` when the caller supplies an
+      explicit algorithm policy. Composed FAPI profiles that narrow the
+      allowlist must pass `true`.
   """
   @spec verify(String.t(), String.t(), String.t() | [String.t()], map() | [map()] | map(), verify_opts()) ::
           {:ok, map()} | {:error, verify_error()}
@@ -92,21 +99,26 @@ defmodule Attesto.ClientAssertion do
   defp verify_signature(assertion, header, trusted_jwks, opts) do
     accepted_algs = Keyword.get(opts, :accepted_algs, SigningAlg.fapi_algs())
 
-    case candidates(trusted_jwks, Map.get(header, "kid"), accepted_algs) do
+    enforce_fapi_policy =
+      Keyword.get(opts, :enforce_fapi_alg_policy, not Keyword.has_key?(opts, :accepted_algs))
+
+    case candidates(trusted_jwks, Map.get(header, "kid"), accepted_algs, enforce_fapi_policy) do
       [] -> {:error, :invalid_signature}
       jwks -> verify_against_any(jwks, assertion)
     end
   end
 
-  defp candidates(trusted_jwks, header_kid, accepted_algs) do
+  defp candidates(trusted_jwks, header_kid, accepted_algs, enforce_fapi_policy) do
     trusted_jwks
     |> normalize_jwks()
     |> Enum.map(fn jwk_map ->
       jwk = JOSE.JWK.from_map(jwk_map)
       alg = Map.get(jwk_map, "alg") || SigningAlg.infer(jwk)
-      {Map.get(jwk_map, "kid"), SigningAlg.validate!(alg), jwk}
+      {Map.get(jwk_map, "kid"), SigningAlg.validate_for_key!(alg, jwk), jwk}
     end)
-    |> Enum.filter(fn {_kid, alg, _jwk} -> alg in accepted_algs end)
+    |> Enum.filter(fn {_kid, alg, jwk} ->
+      alg in accepted_algs and (not enforce_fapi_policy or SigningAlg.fapi_compatible?(alg, jwk))
+    end)
     |> filter_by_kid(header_kid)
   rescue
     _ -> []

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -35,9 +35,12 @@ defmodule Attesto.DPoP do
 
   Per RFC 9449 §4.2, DPoP proofs MUST be signed with an asymmetric
   algorithm. This verifier whitelists `ES256`, `ES384`, `ES512`, `RS256`,
-  `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, and `EdDSA`. Symmetric
-  algorithms (`HS*`) and the unsecured `none` algorithm are rejected;
-  there is no caller-facing knob to relax this.
+  `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, legacy `EdDSA`, and RFC 9864
+  `Ed25519` / `Ed448`, intersected with the algorithms the configured JOSE
+  backend reports as available. The explicit Edwards identifiers must match
+  the embedded public JWK's curve, and RSA proof keys must have a modulus of
+  at least 2048 bits. Symmetric algorithms (`HS*`) and the unsecured `none`
+  algorithm are rejected; there is no caller-facing knob to relax this.
 
   ## Replay protection
 
@@ -65,10 +68,13 @@ defmodule Attesto.DPoP do
   """
 
   alias Attesto.SecureCompare
+  alias Attesto.SigningAlg
   alias Attesto.Thumbprint
 
   # RFC 9449 §4.2: asymmetric algorithms only.
-  @allowed_algs ~w(ES256 ES384 ES512 RS256 RS384 RS512 PS256 PS384 PS512 EdDSA)
+  @allowed_algs ~w(ES256 ES384 ES512 RS256 RS384 RS512 PS256 PS384 PS512 EdDSA Ed25519 Ed448)
+  @rsa_algs ~w(RS256 RS384 RS512 PS256 PS384 PS512)
+  @minimum_rsa_modulus_bits 2048
   @proof_typ "dpop+jwt"
   @default_max_age_seconds 60
   # Match the verifier-wide clock skew used for JWT assertions and ID/access
@@ -182,6 +188,8 @@ defmodule Attesto.DPoP do
          :ok <- check_alg(header),
          :ok <- check_crit(header),
          {:ok, jwk} <- extract_jwk(header),
+         :ok <- check_key_strength(header["alg"], jwk),
+         :ok <- check_edwards_alg_curve(header["alg"], jwk),
          {:ok, claims} <- verify_signature(proof, header["alg"], jwk),
          :ok <- check_htm(claims, opts),
          :ok <- check_htu(claims, opts),
@@ -236,10 +244,13 @@ defmodule Attesto.DPoP do
 
   @doc """
   The list of JOSE `alg` values accepted on a DPoP proof's protected
-  header.
+  header, filtered by the configured JOSE backend's current capabilities.
   """
   @spec allowed_algs() :: [String.t()]
-  def allowed_algs, do: @allowed_algs
+  def allowed_algs do
+    supported = jose_jws_algs()
+    Enum.filter(@allowed_algs, &(&1 in supported))
+  end
 
   # ----- internal: header parsing -----
 
@@ -296,7 +307,7 @@ defmodule Attesto.DPoP do
   defp check_typ(_header), do: {:error, :invalid_typ}
 
   defp check_alg(%{"alg" => alg}) when is_binary(alg) do
-    if alg in @allowed_algs, do: :ok, else: {:error, :invalid_alg}
+    if alg in allowed_algs(), do: :ok, else: {:error, :invalid_alg}
   end
 
   defp check_alg(_header), do: {:error, :invalid_alg}
@@ -344,6 +355,38 @@ defmodule Attesto.DPoP do
     _ -> {:error, :invalid_jwk}
   catch
     _, _ -> {:error, :invalid_jwk}
+  end
+
+  defp check_edwards_alg_curve(alg, jwk) when alg in ["EdDSA", "Ed25519", "Ed448"] do
+    SigningAlg.validate_for_key!(alg, jwk)
+    :ok
+  rescue
+    _ -> {:error, :invalid_jwk}
+  end
+
+  defp check_edwards_alg_curve(_alg, _jwk), do: :ok
+
+  defp check_key_strength(alg, jwk) when alg in @rsa_algs do
+    case JOSE.JWK.to_public_map(jwk) do
+      {_metadata, %{"kty" => "RSA"}} ->
+        if SigningAlg.rsa_modulus_at_least?(jwk, @minimum_rsa_modulus_bits),
+          do: :ok,
+          else: {:error, :invalid_jwk}
+
+      _other ->
+        :ok
+    end
+  end
+
+  defp check_key_strength(_alg, _jwk), do: :ok
+
+  defp jose_jws_algs do
+    case Keyword.get(JOSE.JWA.supports(), :jws) do
+      {:alg, algorithms} when is_list(algorithms) -> algorithms
+      _ -> []
+    end
+  rescue
+    _ -> []
   end
 
   # Private-key components per RFC 7518 §6.2.2 / §6.3.2. Any of these in a

--- a/lib/attesto/id_token.ex
+++ b/lib/attesto/id_token.ex
@@ -13,7 +13,8 @@ defmodule Attesto.IDToken do
   Like `Attesto.Token`, the operations are pure: they read only the
   `Attesto.Config` passed in. Signing uses the same keystore/`kid` path and
   trusted, key-bound algorithm resolution: RS256, PS256, ES256, ES384, ES512,
-  or EdDSA as selected by `Attesto.SigningAlg`. Verification derives each
+  legacy EdDSA, or RFC 9864 Ed25519 / Ed448 as selected by
+  `Attesto.SigningAlg`. Verification derives each
   candidate key's accepted algorithm from per-key keystore metadata or the
   key type and curve rather than the presented header, then calls
   `JOSE.JWT.verify_strict` with that singleton allowlist. `none`, `HS*`, and
@@ -68,7 +69,10 @@ defmodule Attesto.IDToken do
   §3.3.2.11): hash the ASCII octets of the `access_token` / `code` with
   the hash associated with the ID Token's signature algorithm (for example,
   SHA-256 for RS256), take the left-most half of the digest, and
-  base64url-encode it without padding.
+  base64url-encode it without padding. Applying that generic rule to RFC 8032,
+  Ed25519 uses SHA-512 and takes 32 bytes; Ed448 uses SHAKE256 with 114 bytes
+  of output and takes 57 bytes. The trusted signing key curve selects between
+  them; the untrusted JWS header never selects the digest.
   """
 
   alias Attesto.Config
@@ -180,7 +184,9 @@ defmodule Attesto.IDToken do
          {:ok, extra} <- normalize_extra_claims(opts) do
       iat = unix_now(opts)
       lifetime = lifetime_seconds(opts)
-      alg = signing_alg(config)
+      pem = config.keystore.signing_pem()
+      jwk = Key.jwk(pem)
+      alg = SigningAlg.for_key(config.keystore, pem, signing?: true)
 
       claims =
         %{
@@ -195,12 +201,12 @@ defmodule Attesto.IDToken do
         |> put_optional("auth_time", Keyword.get(opts, :auth_time))
         |> put_optional("acr", Keyword.get(opts, :acr))
         |> put_optional("amr", Keyword.get(opts, :amr))
-        |> put_optional("at_hash", hash_claim(Keyword.get(opts, :access_token), alg))
-        |> put_optional("c_hash", hash_claim(Keyword.get(opts, :code), alg))
+        |> put_optional("at_hash", hash_claim(Keyword.get(opts, :access_token), alg, jwk))
+        |> put_optional("c_hash", hash_claim(Keyword.get(opts, :code), alg, jwk))
         |> put_optional("sid", Keyword.get(opts, :sid))
         |> Map.merge(extra)
 
-      {:ok, sign(config, claims, alg)}
+      {:ok, sign(pem, claims, alg)}
     end
   end
 
@@ -316,15 +322,9 @@ defmodule Attesto.IDToken do
 
   # OIDC Core §3.1.3.6: left-most half of the hash of the ASCII octets of
   # the value, base64url-encoded without padding. nil means "not requested".
-  defp hash_claim(nil, _alg), do: nil
+  defp hash_claim(nil, _alg, _jwk), do: nil
 
-  defp hash_claim(value, alg) when is_binary(value) do
-    alg
-    |> SigningAlg.hash_alg()
-    |> :crypto.hash(value)
-    |> binary_part(0, SigningAlg.hash_half_bytes(alg))
-    |> Base.url_encode64(padding: false)
-  end
+  defp hash_claim(value, alg, jwk) when is_binary(value), do: SigningAlg.oidc_hash(value, alg, jwk)
 
   defp normalize_extra_claims(opts) do
     case Keyword.get(opts, :extra_claims) do
@@ -347,14 +347,8 @@ defmodule Attesto.IDToken do
   # `typ: "JWT"` only when the header omits it): emit the protected header
   # `jose_header/1` computes verbatim, exactly as `Attesto.Token` does, so
   # the `typ` is the deliberate `JWT` and the `kid`/`alg` are pinned.
-  defp sign(config, claims, alg) do
-    pem = config.keystore.signing_pem()
+  defp sign(pem, claims, alg) do
     Attesto.JWS.sign_compact(pem, jose_header(pem, alg), claims)
-  end
-
-  defp signing_alg(config) do
-    pem = config.keystore.signing_pem()
-    SigningAlg.for_key(config.keystore, pem, signing?: true)
   end
 
   defp jose_header(pem, alg) do

--- a/lib/attesto/identity_assertion.ex
+++ b/lib/attesto/identity_assertion.ex
@@ -165,7 +165,7 @@ defmodule Attesto.IdentityAssertion do
     |> Enum.map(fn jwk_map ->
       jwk = JOSE.JWK.from_map(jwk_map)
       alg = Map.get(jwk_map, "alg") || SigningAlg.infer(jwk)
-      {Map.get(jwk_map, "kid"), SigningAlg.validate!(alg), jwk}
+      {Map.get(jwk_map, "kid"), SigningAlg.validate_for_key!(alg, jwk), jwk}
     end)
     |> Enum.filter(fn {_kid, alg, _jwk} -> alg in accepted_algs end)
     |> filter_by_kid(header_kid)

--- a/lib/attesto/keystore.ex
+++ b/lib/attesto/keystore.ex
@@ -21,6 +21,11 @@ defmodule Attesto.Keystore do
   consumes the PEMs, so the security-sensitive resolution and any
   fail-fast boot checks stay in the host application.
 
+  A FAPI deployment that uses RSA must provision every server signing and
+  verification key with a modulus of at least 2048 bits. The generic keystore
+  contract remains profile-neutral so non-FAPI applications can make their
+  own compatibility decisions.
+
   `Attesto.Keystore.Static` is a ready-made implementation for the common
   single-key (or manually-rotated) case.
   """
@@ -29,7 +34,8 @@ defmodule Attesto.Keystore do
   The private signing-key PEM used to sign newly issued tokens.
 
   The key must support one of the asymmetric algorithms accepted by
-  `Attesto.SigningAlg`.
+  `Attesto.SigningAlg`. FAPI server deployments using RSA require a modulus of
+  at least 2048 bits.
   """
   @callback signing_pem() :: String.t()
 
@@ -43,10 +49,12 @@ defmodule Attesto.Keystore do
   @doc """
   Optional per-key JOSE algorithm metadata, keyed by RFC 7638 `kid`.
 
-  When omitted, Attesto infers an algorithm from the public key shape:
+  When omitted, Attesto infers an algorithm from the public key type and curve:
   RSA -> RS256, P-256 -> ES256, P-384 -> ES384, P-521 -> ES512, and
-  Ed25519/Ed448 -> EdDSA. Use this callback to label RSA keys that should
-  verify as PS256, or to make a rotation window explicit.
+  Ed25519/Ed448 -> legacy EdDSA. Use this callback to label RSA keys that
+  should verify as PS256, select RFC 9864 `Ed25519` / `Ed448` for the matching
+  curve, or make a rotation window explicit. Ed448 deployments must configure
+  JOSE with Curve448 and SHAKE256 support.
   """
   @callback key_algs() :: %{String.t() => String.t()} | keyword(String.t())
 

--- a/lib/attesto/logout_token.ex
+++ b/lib/attesto/logout_token.ex
@@ -108,7 +108,8 @@ defmodule Attesto.LogoutToken do
          {:ok, identifiers} <- subject_identifiers(opts) do
       iat = unix_now(opts)
       lifetime = lifetime_seconds(opts)
-      alg = signing_alg(config)
+      pem = config.keystore.signing_pem()
+      alg = SigningAlg.for_key(config.keystore, pem, signing?: true)
 
       claims =
         %{
@@ -121,7 +122,7 @@ defmodule Attesto.LogoutToken do
         }
         |> Map.merge(identifiers)
 
-      {:ok, sign(config, claims, alg)}
+      {:ok, sign(pem, claims, alg)}
     end
   end
 
@@ -154,14 +155,8 @@ defmodule Attesto.LogoutToken do
     end
   end
 
-  defp sign(config, claims, alg) do
-    pem = config.keystore.signing_pem()
+  defp sign(pem, claims, alg) do
     Attesto.JWS.sign_compact(pem, jose_header(pem, alg), claims)
-  end
-
-  defp signing_alg(config) do
-    pem = config.keystore.signing_pem()
-    SigningAlg.for_key(config.keystore, pem, signing?: true)
   end
 
   defp jose_header(pem, alg) do

--- a/lib/attesto/request_object.ex
+++ b/lib/attesto/request_object.ex
@@ -17,6 +17,7 @@ defmodule Attesto.RequestObject do
           | {:issuer, String.t() | nil}
           | {:audience, String.t() | [String.t()]}
           | {:accepted_algs, [SigningAlg.alg()]}
+          | {:enforce_fapi_alg_policy, boolean()}
           | {:require_nbf, boolean()}
           | {:max_nbf_age_seconds, pos_integer() | nil}
           | {:require_exp, boolean()}
@@ -51,7 +52,13 @@ defmodule Attesto.RequestObject do
   caller that passes none observes no change:
 
     * `:accepted_algs` - JOSE algorithms a candidate trusted key may use.
-      Defaults to `SigningAlg.fapi_algs/0` (PS256, ES256, EdDSA).
+      Defaults to `SigningAlg.fapi_algs/0` (PS256, ES256, EdDSA over Ed25519,
+      and explicit Ed25519).
+    * `:enforce_fapi_alg_policy` - additionally enforce the FAPI key/algorithm
+      policy, rejecting RSA moduli below 2048 bits and legacy `EdDSA` over
+      Ed448. Defaults to `true` when `:accepted_algs` is omitted and `false`
+      when the caller supplies an explicit non-FAPI algorithm policy. Composed
+      FAPI profiles that narrow the allowlist must pass `true`.
     * `:require_nbf` - when `true`, reject an object without an `nbf` claim.
       Defaults to `false`. (RFC 9101 / FAPI Message Signing 2.0 §5.3.1.)
     * `:max_nbf_age_seconds` - when set, reject an `nbf` older than `now - N`.
@@ -134,21 +141,26 @@ defmodule Attesto.RequestObject do
   defp verify_signature(jwt, header, trusted_jwks, opts) do
     accepted_algs = Keyword.get(opts, :accepted_algs, SigningAlg.fapi_algs())
 
-    case candidates(trusted_jwks, Map.get(header, "kid"), accepted_algs) do
+    enforce_fapi_policy =
+      Keyword.get(opts, :enforce_fapi_alg_policy, not Keyword.has_key?(opts, :accepted_algs))
+
+    case candidates(trusted_jwks, Map.get(header, "kid"), accepted_algs, enforce_fapi_policy) do
       [] -> {:error, :invalid_signature}
       jwks -> verify_against_any(jwks, jwt)
     end
   end
 
-  defp candidates(trusted_jwks, header_kid, accepted_algs) do
+  defp candidates(trusted_jwks, header_kid, accepted_algs, enforce_fapi_policy) do
     trusted_jwks
     |> normalize_jwks()
     |> Enum.map(fn jwk_map ->
       jwk = JOSE.JWK.from_map(jwk_map)
       alg = Map.get(jwk_map, "alg") || SigningAlg.infer(jwk)
-      {Map.get(jwk_map, "kid"), SigningAlg.validate!(alg), jwk}
+      {Map.get(jwk_map, "kid"), SigningAlg.validate_for_key!(alg, jwk), jwk}
     end)
-    |> Enum.filter(fn {_kid, alg, _jwk} -> alg in accepted_algs end)
+    |> Enum.filter(fn {_kid, alg, jwk} ->
+      alg in accepted_algs and (not enforce_fapi_policy or SigningAlg.fapi_compatible?(alg, jwk))
+    end)
     |> filter_by_kid(header_kid)
   rescue
     _ -> []

--- a/lib/attesto/request_object/policy.ex
+++ b/lib/attesto/request_object/policy.ex
@@ -15,6 +15,7 @@ defmodule Attesto.RequestObject.Policy do
 
   @type t :: %__MODULE__{
           accepted_algs: [SigningAlg.alg()] | nil,
+          enforce_fapi_alg_policy: boolean() | nil,
           require_nbf: boolean(),
           max_nbf_age_seconds: pos_integer() | nil,
           require_exp: boolean(),
@@ -24,6 +25,7 @@ defmodule Attesto.RequestObject.Policy do
         }
 
   defstruct accepted_algs: nil,
+            enforce_fapi_alg_policy: nil,
             require_nbf: false,
             max_nbf_age_seconds: nil,
             require_exp: false,
@@ -56,7 +58,10 @@ defmodule Attesto.RequestObject.Policy do
       NOT required.
 
   `accepted_algs` is left `nil` to inherit `Attesto.RequestObject.verify/3`'s
-  default (`Attesto.SigningAlg.fapi_algs/0`: PS256, ES256, EdDSA).
+  default (`Attesto.SigningAlg.fapi_algs/0`: PS256, ES256, legacy EdDSA over
+  Ed25519, and explicit Ed25519). `enforce_fapi_alg_policy` is set explicitly
+  so a caller can narrow `accepted_algs` without disabling the profile's RSA
+  modulus and Edwards-curve checks.
 
   Note on `typ`: §5.3.1's "shall accept that typ" requires an OP to *accept* the
   `oauth-authz-req+jwt` type when a client sends it - it does not license
@@ -70,6 +75,7 @@ defmodule Attesto.RequestObject.Policy do
   @spec fapi_message_signing() :: t()
   def fapi_message_signing do
     %__MODULE__{
+      enforce_fapi_alg_policy: true,
       require_nbf: true,
       max_nbf_age_seconds: 3600,
       require_exp: true,
@@ -89,10 +95,12 @@ defmodule Attesto.RequestObject.Policy do
   def require_request_object?(%__MODULE__{require_request_object: required}), do: required == true
 
   @doc """
-  Flatten the policy to `Attesto.RequestObject.verify/3` options, dropping `nil`
-  values so `verify/3` keeps its own defaults (notably `accepted_algs`, which
-  defaults to `Attesto.SigningAlg.fapi_algs/0`) and the non-verification
-  presence fields (`#{inspect(@non_verify_keys)}`).
+  Flatten the policy to `Attesto.RequestObject.verify/3` options, dropping
+  `nil` values so `verify/3` keeps its own defaults (notably `accepted_algs`,
+  which defaults to `Attesto.SigningAlg.fapi_algs/0`) and the non-verification
+  presence fields (`#{inspect(@non_verify_keys)}`). Boolean `false` remains
+  present, allowing a generic non-FAPI policy to opt out of the FAPI key gate
+  explicitly.
   """
   @spec to_verify_opts(t()) :: keyword()
   def to_verify_opts(%__MODULE__{} = policy) do

--- a/lib/attesto/signing_alg.ex
+++ b/lib/attesto/signing_alg.ex
@@ -5,26 +5,40 @@ defmodule Attesto.SigningAlg do
   Attesto treats the algorithm as metadata of the trusted key selected by
   `kid`, never as policy learned from the presented token. RSA keys infer
   RS256 (RSASSA-PKCS1-v1_5) as the JWA default for the `RSA` key type, while
-  EC/OKP keys infer their JOSE algorithm from the public JWK curve. RSA
-  deployments that intentionally use PS256 can label the key through the
-  keystore's alg metadata.
+  EC/OKP keys infer their JOSE algorithm from the public JWK curve. For wire
+  compatibility, Ed25519 and Ed448 inference retains the legacy `EdDSA`
+  identifier; trusted keystore metadata can opt into RFC 9864's explicit
+  `Ed25519` or `Ed448` identifiers. RSA deployments that intentionally use
+  PS256 can likewise label the key through keystore metadata. Ed448 requires
+  a JOSE backend with Curve448 and SHAKE256 support.
   """
 
   alias Attesto.Key
 
   @type alg :: String.t()
 
-  @allowed ~w(RS256 PS256 ES256 ES384 ES512 EdDSA)
+  @type oidc_hash_profile ::
+          {:fixed, :sha256 | :sha384 | :sha512, pos_integer()}
+          | {:xof, :shake256, pos_integer(), pos_integer()}
+
+  @allowed ~w(RS256 PS256 ES256 ES384 ES512 EdDSA Ed25519 Ed448)
 
   @doc "Algorithms Attesto can sign/verify when backed by a matching key."
   @spec allowed() :: [alg()]
   def allowed, do: @allowed
 
-  @fapi_algs ~w(PS256 ES256 EdDSA)
+  @fapi_algs ~w(PS256 ES256 EdDSA Ed25519)
+  @fapi_min_rsa_modulus_bits 2048
 
   @doc """
-  Signing algorithms permitted for FAPI 2 client authentication and request
-  objects: PS256, ES256, EdDSA.
+  Signing algorithms permitted for FAPI 2 client authentication and, when a
+  signed Request Object is processed, its signature: PS256, ES256, legacy
+  EdDSA over Ed25519, and RFC 9864 Ed25519.
+
+  The algorithm list alone cannot express legacy EdDSA's curve. Verifiers
+  using this policy also call `fapi_compatible?/2`, which requires an RSA
+  modulus of at least 2048 bits and rejects an Ed448 key even when its trusted
+  metadata uses the legacy `EdDSA` identifier.
 
   RS256 (RSASSA-PKCS1-v1_5) is deliberately excluded - FAPI 2 mandates PS256
   for RSA keys. This is the policy gate for verifying a signature a *client*
@@ -38,9 +52,11 @@ defmodule Attesto.SigningAlg do
   Default set of algorithms accepted for signatures a *client* presents
   (client assertions and request objects).
 
-  Equal to `fapi_algs/0`: PS256, ES256, EdDSA. A host with a non-FAPI profile
-  can widen this by passing an explicit `:accepted_algs` opt to the relevant
-  verifier; the default keeps the FAPI 2 gate.
+  Equal to `fapi_algs/0`: PS256, ES256, legacy EdDSA over Ed25519, and explicit
+  Ed25519. A host with a non-FAPI profile can pass an explicit `:accepted_algs`
+  option to the relevant verifier. A composed FAPI profile that narrows this
+  list also passes `enforce_fapi_alg_policy: true` to retain the FAPI 2
+  key-strength and curve gates.
   """
   @spec default_client_algs() :: [alg()]
   def default_client_algs, do: @fapi_algs
@@ -56,15 +72,68 @@ defmodule Attesto.SigningAlg do
   """
   @spec for_key(module(), String.t(), keyword()) :: alg()
   def for_key(keystore, pem, opts \\ []) when is_atom(keystore) and is_binary(pem) do
-    kid = Key.kid(pem)
+    jwk = Key.jwk(pem)
+    kid = JOSE.JWK.thumbprint(jwk)
 
-    alg =
-      key_algs(keystore)
-      |> Map.get(kid)
-      |> fallback_signing_alg(keystore, opts)
-      |> fallback_inferred_alg(Key.jwk(pem))
+    key_algs(keystore)
+    |> Map.get(kid)
+    |> fallback_signing_alg(keystore, opts)
+    |> fallback_inferred_alg(jwk)
+    |> validate_for_key!(jwk)
+  end
 
-    validate!(alg)
+  @doc """
+  Validate an algorithm and bind it to a compatible trusted key.
+
+  RFC 9864's explicit `Ed25519` and `Ed448` identifiers require the matching
+  OKP curve. Legacy `EdDSA` remains compatible with either curve. RSA and EC
+  algorithms are likewise checked against their key type and curve so trusted
+  metadata cannot relabel a key with an incompatible algorithm.
+  """
+  @spec validate_for_key!(term(), JOSE.JWK.t()) :: alg()
+  def validate_for_key!(alg, %JOSE.JWK{} = jwk) do
+    alg = validate!(alg)
+    fields = public_fields(jwk)
+
+    if compatible?(alg, fields) do
+      alg
+    else
+      raise ArgumentError,
+            "signing algorithm #{inspect(alg)} is not compatible with trusted key " <>
+              "#{inspect(Map.take(fields, ["kty", "crv"]))}"
+    end
+  end
+
+  @doc """
+  Whether `alg` and its trusted key satisfy Attesto's default FAPI policy.
+
+  RSA keys require a modulus of at least 2048 bits. The legacy `EdDSA`
+  identifier is accepted only over an Ed25519 key. Ed448 and weaker RSA keys
+  remain available to callers that explicitly select a non-FAPI algorithm
+  policy.
+  """
+  @spec fapi_compatible?(term(), JOSE.JWK.t()) :: boolean()
+  def fapi_compatible?(alg, %JOSE.JWK{} = jwk) do
+    alg = validate_for_key!(alg, jwk)
+    fields = public_fields(jwk)
+
+    alg in @fapi_algs and fapi_key_compatible?(alg, fields)
+  rescue
+    _ -> false
+  end
+
+  @doc """
+  Whether an RSA JWK's unsigned modulus is at least `minimum_bits` long.
+
+  Returns `false` for a non-RSA key or malformed modulus. This keeps protocol
+  policy checks independent from JOSE's backend-specific key representation.
+  """
+  @spec rsa_modulus_at_least?(JOSE.JWK.t(), pos_integer()) :: boolean()
+  def rsa_modulus_at_least?(%JOSE.JWK{} = jwk, minimum_bits) when is_integer(minimum_bits) and minimum_bits > 0 do
+    fields = public_fields(jwk)
+    Map.get(fields, "kty") == "RSA" and rsa_modulus_bits(fields) >= minimum_bits
+  rescue
+    _ -> false
   end
 
   @doc """
@@ -97,24 +166,71 @@ defmodule Attesto.SigningAlg do
     |> infer_from_fields()
   end
 
-  @doc "Return the digest algorithm used by an ID Token hash claim."
+  @doc """
+  Return the fixed digest associated with an ID Token signing algorithm.
+
+  Deprecated because EdDSA's digest is curve-dependent. Its keyless EdDSA
+  result corresponds to Ed25519; use `oidc_hash_profile/2` or `oidc_hash/3`
+  for key-aware calculation.
+  """
+  @deprecated "EdDSA is curve-dependent; use oidc_hash_profile/2 or oidc_hash/3"
   @spec hash_alg(alg()) :: :sha256 | :sha384 | :sha512
   def hash_alg(alg) do
     case validate!(alg) do
-      alg when alg in ~w(RS256 PS256 ES256 EdDSA) -> :sha256
+      alg when alg in ~w(RS256 PS256 ES256) -> :sha256
       "ES384" -> :sha384
-      "ES512" -> :sha512
+      alg when alg in ~w(ES512 EdDSA Ed25519) -> :sha512
+      "Ed448" -> raise ArgumentError, "Ed448 uses SHAKE256; use oidc_hash_profile/2 or oidc_hash/3"
     end
   end
 
-  @doc "Return the number of left-most bytes used for OIDC hash claims."
+  @doc """
+  Return half the fixed digest length for an ID Token signing algorithm.
+
+  Deprecated because EdDSA's digest length is curve-dependent. Its keyless
+  EdDSA result corresponds to Ed25519; use `oidc_hash_profile/2` or
+  `oidc_hash/3` for key-aware calculation.
+  """
+  @deprecated "EdDSA is curve-dependent; use oidc_hash_profile/2 or oidc_hash/3"
   @spec hash_half_bytes(alg()) :: pos_integer()
   def hash_half_bytes(alg) do
-    case hash_alg(alg) do
-      :sha256 -> 16
-      :sha384 -> 24
-      :sha512 -> 32
+    case validate!(alg) do
+      alg when alg in ~w(RS256 PS256 ES256) -> 16
+      "ES384" -> 24
+      alg when alg in ~w(ES512 EdDSA Ed25519) -> 32
+      "Ed448" -> raise ArgumentError, "Ed448 uses SHAKE256; use oidc_hash_profile/2 or oidc_hash/3"
     end
+  end
+
+  @doc """
+  Return the OIDC hash profile bound to `alg` and a trusted key.
+
+  Fixed-output hashes return `{:fixed, digest, half_bytes}`. Ed448 returns
+  `{:xof, :shake256, output_bytes, half_bytes}`, making both SHAKE256 lengths
+  explicit and avoiding the ambiguity of the keyless legacy helpers.
+  """
+  @spec oidc_hash_profile(alg(), JOSE.JWK.t()) :: oidc_hash_profile()
+  def oidc_hash_profile(alg, %JOSE.JWK{} = jwk) do
+    do_oidc_hash_profile(validate_for_key!(alg, jwk), public_fields(jwk))
+  end
+
+  @doc """
+  Calculate an OIDC `at_hash` / `c_hash` value for a key-bound algorithm.
+
+  Applying OIDC's generic "hash associated with the signing algorithm" rule
+  to RFC 8032, legacy EdDSA selects from the trusted key curve: SHA-512 (left
+  32 bytes) for Ed25519, or SHAKE256 with 114 bytes of output (left 57 bytes)
+  for Ed448. SHAKE256 is invoked through JOSE's configured SHA3 module,
+  preserving the application's chosen pure-Erlang, NIF, or driver backend.
+  """
+  @spec oidc_hash(binary(), alg(), JOSE.JWK.t()) :: String.t()
+  def oidc_hash(value, alg, %JOSE.JWK{} = jwk) when is_binary(value) do
+    profile = oidc_hash_profile(alg, jwk)
+
+    profile
+    |> digest(value)
+    |> binary_part(0, profile_half_bytes(profile))
+    |> Base.url_encode64(padding: false)
   end
 
   @doc "Validate that `alg` is one of Attesto's supported asymmetric JOSE algorithms."
@@ -175,4 +291,79 @@ defmodule Attesto.SigningAlg do
 
   defp curve_suffix(%{"crv" => crv}), do: " curve #{inspect(crv)}"
   defp curve_suffix(_), do: ""
+
+  defp compatible?(alg, %{"kty" => "RSA"}) when alg in ~w(RS256 PS256), do: true
+  defp compatible?("ES256", %{"kty" => "EC", "crv" => "P-256"}), do: true
+  defp compatible?("ES384", %{"kty" => "EC", "crv" => "P-384"}), do: true
+  defp compatible?("ES512", %{"kty" => "EC", "crv" => "P-521"}), do: true
+  defp compatible?("EdDSA", %{"kty" => "OKP", "crv" => crv}) when crv in ["Ed25519", "Ed448"], do: true
+  defp compatible?("Ed25519", %{"kty" => "OKP", "crv" => "Ed25519"}), do: true
+  defp compatible?("Ed448", %{"kty" => "OKP", "crv" => "Ed448"}), do: true
+  defp compatible?(_alg, _fields), do: false
+
+  defp fapi_key_compatible?("PS256", %{"kty" => "RSA"} = fields) do
+    rsa_modulus_bits(fields) >= @fapi_min_rsa_modulus_bits
+  end
+
+  defp fapi_key_compatible?("EdDSA", %{"kty" => "OKP", "crv" => "Ed25519"}), do: true
+  defp fapi_key_compatible?("EdDSA", _fields), do: false
+  defp fapi_key_compatible?(_alg, _fields), do: true
+
+  defp rsa_modulus_bits(%{"n" => encoded_modulus}) when is_binary(encoded_modulus) do
+    with {:ok, modulus_bytes} <- Base.url_decode64(encoded_modulus, padding: false),
+         modulus when modulus > 0 <- :binary.decode_unsigned(modulus_bytes) do
+      modulus
+      |> Integer.to_string(2)
+      |> byte_size()
+    else
+      _ -> 0
+    end
+  end
+
+  defp rsa_modulus_bits(_fields), do: 0
+
+  defp do_oidc_hash_profile(alg, _fields) when alg in ~w(RS256 PS256 ES256), do: {:fixed, :sha256, 16}
+  defp do_oidc_hash_profile("ES384", _fields), do: {:fixed, :sha384, 24}
+  defp do_oidc_hash_profile("ES512", _fields), do: {:fixed, :sha512, 32}
+  defp do_oidc_hash_profile("EdDSA", %{"kty" => "OKP", "crv" => "Ed25519"}), do: {:fixed, :sha512, 32}
+  defp do_oidc_hash_profile("EdDSA", %{"kty" => "OKP", "crv" => "Ed448"}), do: {:xof, :shake256, 114, 57}
+  defp do_oidc_hash_profile("Ed25519", _fields), do: {:fixed, :sha512, 32}
+  defp do_oidc_hash_profile("Ed448", _fields), do: {:xof, :shake256, 114, 57}
+
+  defp profile_half_bytes({:fixed, _algorithm, half_bytes}), do: half_bytes
+  defp profile_half_bytes({:xof, _algorithm, _output_bytes, half_bytes}), do: half_bytes
+
+  defp digest({:fixed, algorithm, _half_bytes}, value), do: :crypto.hash(algorithm, value)
+
+  defp digest({:xof, :shake256, output_bytes, _half_bytes}, value) do
+    digest_shake256(JOSE.sha3_module(), value, output_bytes)
+  end
+
+  defp digest_shake256(sha3_module, value, output_bytes) do
+    case Code.ensure_loaded(sha3_module) do
+      {:module, _module} ->
+        if function_exported?(sha3_module, :shake256, 2) do
+          sha3_module.shake256(value, output_bytes)
+        else
+          raise_missing_sha3!(sha3_module, "shake256/2 is not exported")
+        end
+
+      {:error, reason} ->
+        raise_missing_sha3!(sha3_module, "module could not be loaded: #{inspect(reason)}")
+    end
+  rescue
+    error in ErlangError ->
+      if error.original == :operation_not_supported do
+        raise_missing_sha3!(sha3_module, Exception.message(error))
+      else
+        reraise error, __STACKTRACE__
+      end
+  end
+
+  defp raise_missing_sha3!(sha3_module, detail) do
+    raise ArgumentError,
+          "Ed448 OIDC hash claims require a configured JOSE SHA3 backend with " <>
+            "SHAKE256 support; #{inspect(sha3_module)} could not provide shake256/2 " <>
+            "(#{detail})"
+  end
 end

--- a/lib/attesto/test/dpop.ex
+++ b/lib/attesto/test/dpop.ex
@@ -122,9 +122,9 @@ defmodule Attesto.Test.DPoP do
   The proof carries the protected header `%{"typ" => "dpop+jwt", "alg" =>
   ..., "jwk" => <public jwk>}` and the payload `%{"htm" => htm, "htu" =>
   htu, "iat" => now, "jti" => <random>}` (RFC 9449 §4.2). The signing
-  `alg` is derived from the key shape via `Attesto.SigningAlg`, and only
-  the key's public half is embedded, so the result verifies under
-  `Attesto.DPoP.verify_proof/2`.
+  `alg` defaults to the legacy identifier derived from the key via
+  `Attesto.SigningAlg`, and only the key's public half is embedded, so the
+  result verifies under `Attesto.DPoP.verify_proof/2`.
 
   Options:
 
@@ -138,10 +138,13 @@ defmodule Attesto.Test.DPoP do
       to `DateTime.utc_now/0`.
     * `:jti` - override the random replay identifier (e.g. to drive a
       replay test that presents the same `jti` twice).
+    * `:alg` - override the inferred identifier with any key-compatible
+      algorithm accepted by `Attesto.DPoP.allowed_algs/0`, including RFC 9864
+      `Ed25519` or `Ed448` when the configured JOSE backend supports it.
   """
   @spec proof(JOSE.JWK.t(), String.t(), String.t(), keyword()) :: String.t()
   def proof(%JOSE.JWK{} = jwk, htm, htu, opts \\ []) when is_binary(htm) and is_binary(htu) and is_list(opts) do
-    sign(jwk, payload(htm, htu, opts))
+    sign(jwk, payload(htm, htu, opts), opts)
   end
 
   @doc """
@@ -158,7 +161,7 @@ defmodule Attesto.Test.DPoP do
   @spec invalid_proof(JOSE.JWK.t(), flaw(), String.t(), String.t(), keyword()) :: String.t()
   def invalid_proof(%JOSE.JWK{} = jwk, flaw, htm, htu, opts \\ [])
       when is_binary(htm) and is_binary(htu) and is_list(opts) do
-    sign(jwk, flawed_payload(flaw, htm, htu, opts))
+    sign(jwk, flawed_payload(flaw, htm, htu, opts), opts)
   end
 
   # ----- internal: payloads -----
@@ -222,9 +225,10 @@ defmodule Attesto.Test.DPoP do
   # `JOSE.JWT`) so the protected header is emitted verbatim and the
   # `typ: "dpop+jwt"` survives, then compact. Only the public half of the
   # key is embedded in `jwk`, as RFC 9449 §4.2 requires.
-  defp sign(jwk, payload) do
+  defp sign(jwk, payload, opts) do
     pub = public_jwk(jwk)
-    alg = SigningAlg.infer(jwk)
+    alg = Keyword.get(opts, :alg, SigningAlg.infer(jwk))
+    alg = validate_dpop_alg!(alg, jwk)
     header = %{"typ" => @proof_typ, "alg" => alg, "jwk" => public_jwk_map(pub)}
     signed = JOSE.JWS.sign(jwk, JSON.encode!(payload), header)
     {_protected, compact} = JOSE.JWS.compact(signed)
@@ -232,6 +236,19 @@ defmodule Attesto.Test.DPoP do
   end
 
   defp public_jwk(jwk), do: JOSE.JWK.to_public(jwk)
+
+  defp validate_dpop_alg!(alg, jwk) when is_binary(alg) do
+    if alg not in DPoP.allowed_algs() do
+      raise ArgumentError, "unsupported DPoP signing algorithm #{inspect(alg)} for the configured JOSE backend"
+    end
+
+    {_modules, fields} = JOSE.JWK.to_public_map(jwk)
+
+    case {alg, fields} do
+      {rsa_alg, %{"kty" => "RSA"}} when rsa_alg in ~w(RS256 RS384 RS512 PS256 PS384 PS512) -> alg
+      _ -> SigningAlg.validate_for_key!(alg, jwk)
+    end
+  end
 
   defp public_jwk_map(pub) do
     {_modules, map} = JOSE.JWK.to_map(pub)

--- a/lib/attesto/token.ex
+++ b/lib/attesto/token.ex
@@ -35,7 +35,9 @@ defmodule Attesto.Token do
   algorithm resolved by `Attesto.SigningAlg`. Minting resolves that algorithm
   from per-key `key_algs/0` metadata, then `signing_alg/0` for the current
   signing key, then the trusted key type and curve. The supported set is
-  RS256, PS256, ES256, ES384, ES512, and EdDSA; RSA defaults to RS256.
+  RS256, PS256, ES256, ES384, ES512, legacy EdDSA, and RFC 9864 Ed25519 / Ed448;
+  RSA defaults to RS256, while Edwards-curve inference retains EdDSA for wire
+  compatibility unless trusted metadata selects an explicit identifier.
 
   Verification never learns algorithm policy from the presented JWS header.
   The header `kid` only narrows the configured verification-key set; each

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.2.5"
+  @version "1.3.0"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 
@@ -54,7 +54,7 @@ defmodule Attesto.MixProject do
 
   defp deps do
     [
-      {:jose, "~> 1.11.12"},
+      {:jose, ">= 1.11.12 and < 2.0.0"},
       # Optional: the Attesto.Plug.* integration layer. Hosts that use the
       # plugs already have Plug; the core library does not require it.
       {:plug, "~> 1.16.6 or ~> 1.17.4 or ~> 1.18.5 or ~> 1.19.5 or >= 1.20.3 and < 2.0.0", optional: true},

--- a/test/attesto/ciba_request_test.exs
+++ b/test/attesto/ciba_request_test.exs
@@ -1,6 +1,6 @@
 defmodule Attesto.CIBA.RequestTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Attesto.CIBA.Request
 
@@ -207,7 +207,7 @@ defmodule Attesto.CIBA.RequestTest do
 
   defp ec_key, do: JOSE.JWK.generate_key({:ec, "P-256"})
 
-  defp public_jwk(jwk, overrides \\ %{}) do
+  defp public_jwk(jwk, overrides) do
     {_kty, map} = JOSE.JWK.to_public_map(jwk)
     Map.merge(map, Map.merge(%{"kid" => JOSE.JWK.thumbprint(jwk), "alg" => "ES256"}, overrides))
   end
@@ -235,8 +235,9 @@ defmodule Attesto.CIBA.RequestTest do
     compact
   end
 
-  defp signing_client(jwk, overrides \\ %{}) do
-    client(Map.merge(%{jwks: %{"keys" => [public_jwk(jwk)]}}, overrides))
+  defp signing_client(jwk, overrides \\ %{}, alg \\ "ES256") do
+    trusted = public_jwk(jwk, %{"alg" => alg})
+    client(Map.merge(%{jwks: %{"keys" => [trusted]}}, overrides))
   end
 
   defp signed_opts, do: [issuer: @issuer]
@@ -288,6 +289,29 @@ defmodule Attesto.CIBA.RequestTest do
       assert {:error, :invalid_request} = Request.validate(client, %{"request" => jwt}, signed_opts())
     end
 
+    test "the derived FAPI policy rejects PS256 with an RSA modulus below 2048 bits" do
+      key = JOSE.JWK.generate_key({:rsa, 1024})
+      jwt = signed_request(key, %{}, %{"alg" => "PS256"})
+      client = signing_client(key, %{}, "PS256")
+
+      assert {:error, :invalid_request} =
+               Request.validate(client, %{"request" => jwt}, signed_opts())
+
+      assert {:error, :invalid_request} =
+               Request.validate(
+                 client,
+                 %{"request" => jwt},
+                 signed_opts() ++ [accepted_algs: ["PS256"], enforce_fapi_alg_policy: true]
+               )
+
+      assert {:ok, _request} =
+               Request.validate(
+                 client,
+                 %{"request" => jwt},
+                 signed_opts() ++ [accepted_algs: ["PS256"]]
+               )
+    end
+
     test "the client's registered signing alg pins the accepted algorithm" do
       key = ec_key()
       jwt = signed_request(key)
@@ -318,6 +342,42 @@ defmodule Attesto.CIBA.RequestTest do
                  %{"request" => jwt},
                  signed_opts() ++ [accepted_algs: ["PS256"]]
                )
+    end
+
+    test "the derived default policy accepts Ed25519 identifiers but still rejects Ed448" do
+      ed25519 = JOSE.JWK.generate_key({:okp, :Ed25519})
+
+      for alg <- ["EdDSA", "Ed25519"] do
+        jwt = signed_request(ed25519, %{}, %{"alg" => alg})
+
+        assert {:ok, _request} =
+                 Request.validate(signing_client(ed25519, %{}, alg), %{"request" => jwt}, signed_opts())
+      end
+
+      enable_ed448_support()
+      ed448 = JOSE.JWK.generate_key({:okp, :Ed448})
+
+      for alg <- ["EdDSA", "Ed448"] do
+        jwt = signed_request(ed448, %{}, %{"alg" => alg})
+        client = signing_client(ed448, %{}, alg)
+
+        assert {:error, :invalid_request} =
+                 Request.validate(client, %{"request" => jwt}, signed_opts())
+
+        assert {:error, :invalid_request} =
+                 Request.validate(
+                   client,
+                   %{"request" => jwt},
+                   signed_opts() ++ [accepted_algs: [alg], enforce_fapi_alg_policy: true]
+                 )
+
+        assert {:ok, _request} =
+                 Request.validate(
+                   client,
+                   %{"request" => jwt},
+                   signed_opts() ++ [accepted_algs: [alg]]
+                 )
+      end
     end
 
     test "each of the §7.1.1 REQUIRED claims is enforced" do
@@ -464,5 +524,11 @@ defmodule Attesto.CIBA.RequestTest do
                  signed_opts() ++ [require_signed_request: true]
                )
     end
+  end
+
+  defp enable_ed448_support do
+    previous = JOSE.crypto_fallback()
+    JOSE.crypto_fallback(true)
+    on_exit(fn -> JOSE.crypto_fallback(previous) end)
   end
 end

--- a/test/attesto/client_assertion_test.exs
+++ b/test/attesto/client_assertion_test.exs
@@ -1,6 +1,6 @@
 defmodule Attesto.ClientAssertionTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Attesto.ClientAssertion
 
@@ -14,7 +14,7 @@ defmodule Attesto.ClientAssertionTest do
     Map.merge(map, Map.merge(%{"kid" => JOSE.JWK.thumbprint(jwk), "alg" => "ES256"}, overrides))
   end
 
-  defp assertion(jwk, overrides \\ %{}) do
+  defp assertion(jwk, overrides \\ %{}, alg \\ "ES256") do
     now = System.system_time(:second)
 
     claims =
@@ -30,7 +30,7 @@ defmodule Attesto.ClientAssertionTest do
         overrides
       )
 
-    header = %{"alg" => "ES256", "kid" => JOSE.JWK.thumbprint(jwk)}
+    header = %{"alg" => alg, "kid" => JOSE.JWK.thumbprint(jwk)}
     {_header, compact} = jwk |> JOSE.JWT.sign(header, claims) |> JOSE.JWS.compact()
     compact
   end
@@ -106,6 +106,24 @@ defmodule Attesto.ClientAssertionTest do
              ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [jwk]})
   end
 
+  test "the FAPI default rejects PS256 with an RSA modulus below 2048 bits" do
+    key = JOSE.JWK.generate_key({:rsa, 1024})
+    jwt = assertion(key, %{}, "PS256")
+    trusted = public_jwk(key, %{"alg" => "PS256"})
+
+    assert {:error, :invalid_signature} =
+             ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [trusted]})
+
+    assert {:error, :invalid_signature} =
+             ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [trusted]},
+               accepted_algs: ["PS256"],
+               enforce_fapi_alg_policy: true
+             )
+
+    assert {:ok, _claims} =
+             ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [trusted]}, accepted_algs: ["PS256"])
+  end
+
   test "default :accepted_algs keeps the FAPI set (current behaviour)" do
     key = ec_key()
     jwt = assertion(key)
@@ -132,5 +150,45 @@ defmodule Attesto.ClientAssertionTest do
              ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [public_jwk(key)]},
                accepted_algs: ["ES256"]
              )
+  end
+
+  test "the FAPI default accepts legacy EdDSA and RFC 9864 Ed25519 only over Ed25519" do
+    key = JOSE.JWK.generate_key({:okp, :Ed25519})
+
+    for alg <- ["EdDSA", "Ed25519"] do
+      jwt = assertion(key, %{}, alg)
+      trusted = public_jwk(key, %{"alg" => alg})
+
+      assert {:ok, _claims} =
+               ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [trusted]})
+    end
+  end
+
+  test "the FAPI default rejects Ed448 but an explicit non-FAPI policy can opt in" do
+    enable_ed448_support()
+    key = JOSE.JWK.generate_key({:okp, :Ed448})
+
+    for alg <- ["EdDSA", "Ed448"] do
+      jwt = assertion(key, %{}, alg)
+      trusted = public_jwk(key, %{"alg" => alg})
+
+      assert {:error, :invalid_signature} =
+               ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [trusted]})
+
+      assert {:error, :invalid_signature} =
+               ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [trusted]},
+                 accepted_algs: [alg],
+                 enforce_fapi_alg_policy: true
+               )
+
+      assert {:ok, _claims} =
+               ClientAssertion.verify(jwt, @client_id, @audience, %{"keys" => [trusted]}, accepted_algs: [alg])
+    end
+  end
+
+  defp enable_ed448_support do
+    previous = JOSE.crypto_fallback()
+    JOSE.crypto_fallback(true)
+    on_exit(fn -> JOSE.crypto_fallback(previous) end)
   end
 end

--- a/test/attesto/dpop_test.exs
+++ b/test/attesto/dpop_test.exs
@@ -1,6 +1,6 @@
 defmodule Attesto.DPoPTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Attesto.DPoP
   alias Attesto.Test.Factory
@@ -111,6 +111,46 @@ defmodule Attesto.DPoPTest do
 
       assert {:ok, %{jkt: jkt}} = DPoP.verify_proof(proof, base_opts())
       assert jkt == JOSE.JWK.thumbprint(key)
+    end
+
+    test "rejects RSA proof keys with moduli below 2048 bits" do
+      key = gen_rsa_key(1024)
+
+      for alg <- ~w(RS256 RS384 RS512 PS256 PS384 PS512) do
+        header = build_header(public_map(key), %{"alg" => alg})
+        proof = sign_proof(key, header, build_claims())
+
+        assert {:error, :invalid_jwk} = DPoP.verify_proof(proof, base_opts()),
+               "expected 1024-bit #{alg} proof key to be rejected"
+      end
+    end
+
+    test "verifies RFC 9864 Ed25519 and Ed448 proofs" do
+      ed25519 = JOSE.JWK.generate_key({:okp, :Ed25519})
+      ed25519_proof = sign_proof(ed25519, build_header(public_map(ed25519), %{"alg" => "Ed25519"}), build_claims())
+      assert {:ok, _result} = DPoP.verify_proof(ed25519_proof, base_opts())
+
+      enable_ed448_support()
+      ed448 = JOSE.JWK.generate_key({:okp, :Ed448})
+      ed448_proof = sign_proof(ed448, build_header(public_map(ed448), %{"alg" => "Ed448"}), build_claims())
+      assert {:ok, _result} = DPoP.verify_proof(ed448_proof, base_opts())
+    end
+
+    test "rejects an explicit Edwards identifier that does not match the embedded curve" do
+      enable_ed448_support()
+      key = JOSE.JWK.generate_key({:okp, :Ed448})
+      proof = sign_proof(key, build_header(public_map(key), %{"alg" => "Ed448"}), build_claims())
+      [_header, payload, signature] = String.split(proof, ".")
+
+      mismatched_header =
+        key
+        |> public_map()
+        |> build_header(%{"alg" => "Ed25519"})
+        |> JSON.encode!()
+        |> Base.url_encode64(padding: false)
+
+      assert {:error, :invalid_jwk} =
+               DPoP.verify_proof(Enum.join([mismatched_header, payload, signature], "."), base_opts())
     end
 
     test "ath is verified when :access_token is provided" do
@@ -235,6 +275,10 @@ defmodule Attesto.DPoPTest do
       assert "RS256" in algs
       assert "PS256" in algs
       assert "EdDSA" in algs
+      assert "Ed25519" in algs
+
+      {:alg, jose_jws_algs} = Keyword.fetch!(JOSE.JWA.supports(), :jws)
+      assert "Ed448" in algs == "Ed448" in jose_jws_algs
     end
   end
 
@@ -778,6 +822,12 @@ defmodule Attesto.DPoPTest do
         end
       end
     end
+  end
+
+  defp enable_ed448_support do
+    previous = JOSE.crypto_fallback()
+    JOSE.crypto_fallback(true)
+    on_exit(fn -> JOSE.crypto_fallback(previous) end)
   end
 end
 

--- a/test/attesto/id_token_test.exs
+++ b/test/attesto/id_token_test.exs
@@ -4,6 +4,7 @@ defmodule Attesto.IDTokenTest do
   # env (Attesto.Keystore.Static singleton), so these run serially.
   use ExUnit.Case, async: false
 
+  alias __MODULE__.RotatingKeystore
   alias Attesto.IDToken
   alias Attesto.Key
   alias Attesto.Test.Factory
@@ -167,21 +168,30 @@ defmodule Attesto.IDTokenTest do
   end
 
   describe "trusted key-bound signing algorithms" do
-    for {alg, key} <- [
-          {"RS256", :rsa},
-          {"PS256", :rsa},
-          {"ES256", {:ec, "P-256"}},
-          {"ES384", {:ec, "P-384"}},
-          {"ES512", {:ec, "P-521"}},
-          {"EdDSA", :ed25519}
+    for {alg, key, digest, half_bytes} <- [
+          {"RS256", :rsa, :sha256, 16},
+          {"PS256", :rsa, :sha256, 16},
+          {"ES256", {:ec, "P-256"}, :sha256, 16},
+          {"ES384", {:ec, "P-384"}, :sha384, 24},
+          {"ES512", {:ec, "P-521"}, :sha512, 32},
+          {"EdDSA", :ed25519, :sha512, 32},
+          {"Ed25519", :ed25519, :sha512, 32}
         ] do
-      test "#{alg} mint and verify agree" do
+      test "#{alg} mint, verify, and OIDC hash claims agree" do
         alg = unquote(alg)
+        digest = unquote(digest)
+        half_bytes = unquote(half_bytes)
         pem = signing_pem(unquote(Macro.escape(key)))
-        config_opts = if alg == "PS256", do: [signing_alg: alg], else: []
+        config_opts = if alg in ["PS256", "Ed25519"], do: [signing_alg: alg], else: []
         config = Factory.config(pem, config_opts)
+        access_token = "access-token-#{alg}"
+        code = "authorization-code-#{alg}"
 
-        assert {:ok, jwt} = IDToken.mint(config, @subject, @client_id)
+        assert {:ok, jwt} =
+                 IDToken.mint(config, @subject, @client_id,
+                   access_token: access_token,
+                   code: code
+                 )
 
         assert header!(jwt) == %{
                  "alg" => alg,
@@ -189,9 +199,67 @@ defmodule Attesto.IDTokenTest do
                  "typ" => "JWT"
                }
 
+        assert payload!(jwt)["at_hash"] == oidc_hash(access_token, digest, half_bytes)
+        assert payload!(jwt)["c_hash"] == oidc_hash(code, digest, half_bytes)
+
         assert {:ok, claims} = IDToken.verify(config, jwt, client_id: @client_id)
         assert claims["sub"] == @subject
       end
+    end
+
+    test "Ed448 mint, verify, and OIDC hash claims use SHAKE256/114 left 57" do
+      enable_ed448_support()
+      pem = Factory.ed448_pem()
+      config = Factory.config(pem)
+      access_token = "access-token-Ed448"
+      code = "authorization-code-Ed448"
+
+      assert {:ok, jwt} =
+               IDToken.mint(config, @subject, @client_id,
+                 access_token: access_token,
+                 code: code
+               )
+
+      assert header!(jwt) == %{
+               "alg" => "EdDSA",
+               "kid" => Key.kid(pem),
+               "typ" => "JWT"
+             }
+
+      assert payload!(jwt)["at_hash"] == oidc_shake256_hash(access_token)
+      assert payload!(jwt)["c_hash"] == oidc_shake256_hash(code)
+
+      assert {:ok, claims} = IDToken.verify(config, jwt, client_id: @client_id)
+      assert claims["sub"] == @subject
+    end
+
+    test "RFC 9864 Ed448 mint and verify uses the explicit identifier with the same hash profile" do
+      enable_ed448_support()
+      pem = Factory.ed448_pem()
+      config = Factory.config(pem, signing_alg: "Ed448")
+      access_token = "access-token-explicit-Ed448"
+
+      assert {:ok, jwt} =
+               IDToken.mint(config, @subject, @client_id, access_token: access_token)
+
+      assert header!(jwt)["alg"] == "Ed448"
+      assert payload!(jwt)["at_hash"] == oidc_shake256_hash(access_token)
+      assert {:ok, _claims} = IDToken.verify(config, jwt, client_id: @client_id)
+    end
+
+    test "mint reads a rotating keystore's signing PEM exactly once" do
+      first_pem = Factory.rsa_pem()
+      second_pem = Factory.ed_pem()
+      RotatingKeystore.install([first_pem, second_pem])
+      config = %{Factory.config(first_pem) | keystore: RotatingKeystore}
+
+      assert {:ok, jwt} =
+               IDToken.mint(config, @subject, @client_id, access_token: "rotation-race-access-token")
+
+      assert RotatingKeystore.signing_pem_calls() == 1
+      assert header!(jwt)["alg"] == "RS256"
+      assert header!(jwt)["kid"] == Key.kid(first_pem)
+      assert {:ok, _claims} = IDToken.verify(config, jwt, client_id: @client_id)
     end
   end
 
@@ -515,4 +583,48 @@ defmodule Attesto.IDTokenTest do
   defp signing_pem(:rsa), do: Factory.rsa_pem()
   defp signing_pem({:ec, curve}), do: Factory.ec_pem(curve)
   defp signing_pem(:ed25519), do: Factory.ed_pem()
+
+  defp enable_ed448_support do
+    previous = JOSE.crypto_fallback()
+    JOSE.crypto_fallback(true)
+    on_exit(fn -> JOSE.crypto_fallback(previous) end)
+  end
+
+  defp oidc_hash(value, digest, half_bytes) do
+    value
+    |> then(&:crypto.hash(digest, &1))
+    |> binary_part(0, half_bytes)
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp oidc_shake256_hash(value) do
+    value
+    |> JOSE.sha3_module().shake256(114)
+    |> binary_part(0, 57)
+    |> Base.url_encode64(padding: false)
+  end
+
+  defmodule RotatingKeystore do
+    @moduledoc false
+    @behaviour Attesto.Keystore
+
+    def install(pems) do
+      Process.put({__MODULE__, :remaining}, pems)
+      Process.put({__MODULE__, :all}, pems)
+      Process.put({__MODULE__, :calls}, 0)
+    end
+
+    def signing_pem_calls, do: Process.get({__MODULE__, :calls}, 0)
+
+    @impl true
+    def signing_pem do
+      [pem | rest] = Process.get({__MODULE__, :remaining})
+      Process.put({__MODULE__, :remaining}, rest)
+      Process.put({__MODULE__, :calls}, signing_pem_calls() + 1)
+      pem
+    end
+
+    @impl true
+    def verification_pems, do: Process.get({__MODULE__, :all})
+  end
 end

--- a/test/attesto/logout_token_test.exs
+++ b/test/attesto/logout_token_test.exs
@@ -4,6 +4,7 @@ defmodule Attesto.LogoutTokenTest do
   # (Attesto.Keystore.Static singleton), so these run serially.
   use ExUnit.Case, async: false
 
+  alias __MODULE__.RotatingKeystore
   alias Attesto.IDToken
   alias Attesto.Key
   alias Attesto.LogoutToken
@@ -97,6 +98,20 @@ defmodule Attesto.LogoutTokenTest do
       jwk = Key.jwk(pem)
       assert {true, _, _} = JOSE.JWT.verify_strict(jwk, [IDToken.signing_alg()], jwt)
     end
+
+    test "reads a rotating keystore's signing PEM exactly once" do
+      first_pem = Factory.rsa_pem()
+      second_pem = Factory.ed_pem()
+      RotatingKeystore.install([first_pem, second_pem])
+      config = %{Factory.config(first_pem) | keystore: RotatingKeystore}
+
+      assert {:ok, jwt} = LogoutToken.mint(config, @client_id, sub: @subject)
+
+      assert RotatingKeystore.signing_pem_calls() == 1
+      assert header!(jwt)["alg"] == "RS256"
+      assert header!(jwt)["kid"] == Key.kid(first_pem)
+      assert {true, _, _} = JOSE.JWT.verify_strict(Key.jwk(first_pem), ["RS256"], jwt)
+    end
   end
 
   describe "mint/3 errors" do
@@ -113,5 +128,29 @@ defmodule Attesto.LogoutTokenTest do
   test "event_uri/0 and header_typ/0 expose the constants" do
     assert LogoutToken.event_uri() == @event_uri
     assert LogoutToken.header_typ() == "logout+jwt"
+  end
+
+  defmodule RotatingKeystore do
+    @moduledoc false
+    @behaviour Attesto.Keystore
+
+    def install(pems) do
+      Process.put({__MODULE__, :remaining}, pems)
+      Process.put({__MODULE__, :all}, pems)
+      Process.put({__MODULE__, :calls}, 0)
+    end
+
+    def signing_pem_calls, do: Process.get({__MODULE__, :calls}, 0)
+
+    @impl true
+    def signing_pem do
+      [pem | rest] = Process.get({__MODULE__, :remaining})
+      Process.put({__MODULE__, :remaining}, rest)
+      Process.put({__MODULE__, :calls}, signing_pem_calls() + 1)
+      pem
+    end
+
+    @impl true
+    def verification_pems, do: Process.get({__MODULE__, :all})
   end
 end

--- a/test/attesto/request_object_policy_test.exs
+++ b/test/attesto/request_object_policy_test.exs
@@ -14,6 +14,7 @@ defmodule Attesto.RequestObject.PolicyTest do
       refute Keyword.has_key?(opts, :max_nbf_age_seconds)
       refute Keyword.has_key?(opts, :max_lifetime_seconds)
       refute Keyword.has_key?(opts, :accepted_typ)
+      refute Keyword.has_key?(opts, :enforce_fapi_alg_policy)
       assert Keyword.get(opts, :require_nbf) == false
       assert Keyword.get(opts, :require_exp) == false
     end
@@ -31,6 +32,15 @@ defmodule Attesto.RequestObject.PolicyTest do
       assert Keyword.get(opts, :accepted_typ) == ["oauth-authz-req+jwt", nil]
       # accepted_algs is left nil so verify/3's fapi_algs() default applies.
       refute Keyword.has_key?(opts, :accepted_algs)
+      assert Keyword.get(opts, :enforce_fapi_alg_policy) == true
+    end
+
+    test "algorithm-policy intent survives a narrowed allowlist" do
+      fapi_policy = %{Policy.fapi_message_signing() | accepted_algs: ["PS256"]}
+      assert Keyword.get(Policy.to_verify_opts(fapi_policy), :enforce_fapi_alg_policy) == true
+
+      non_fapi_policy = %Policy{accepted_algs: ["PS256"], enforce_fapi_alg_policy: false}
+      assert Keyword.get(Policy.to_verify_opts(non_fapi_policy), :enforce_fapi_alg_policy) == false
     end
 
     test "the presence flag is never leaked into the per-object verify opts" do

--- a/test/attesto/request_object_test.exs
+++ b/test/attesto/request_object_test.exs
@@ -1,8 +1,9 @@
 defmodule Attesto.RequestObjectTest do
   @moduledoc false
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Attesto.RequestObject
+  alias Attesto.RequestObject.Policy
 
   @client_id "client-123"
   @issuer @client_id
@@ -58,6 +59,29 @@ defmodule Attesto.RequestObjectTest do
                RequestObject.verify(jwt, %{"keys" => [jwk]}, base_opts())
     end
 
+    test "the FAPI default rejects PS256 with an RSA modulus below 2048 bits" do
+      key = JOSE.JWK.generate_key({:rsa, 1024})
+      jwt = request_object(key, %{}, %{"alg" => "PS256"})
+      trusted = public_jwk(key, %{"alg" => "PS256"})
+
+      assert {:error, :invalid_signature} =
+               RequestObject.verify(jwt, %{"keys" => [trusted]}, base_opts())
+
+      assert {:error, :invalid_signature} =
+               RequestObject.verify(
+                 jwt,
+                 %{"keys" => [trusted]},
+                 base_opts() ++ [accepted_algs: ["PS256"], enforce_fapi_alg_policy: true]
+               )
+
+      assert {:ok, _params} =
+               RequestObject.verify(
+                 jwt,
+                 %{"keys" => [trusted]},
+                 base_opts() ++ [accepted_algs: ["PS256"]]
+               )
+    end
+
     test "explicitly narrowing accepted_algs rejects an otherwise-accepted alg" do
       key = ec_key()
       jwt = request_object(key)
@@ -80,6 +104,68 @@ defmodule Attesto.RequestObjectTest do
                  %{"keys" => [public_jwk(key)]},
                  base_opts() ++ [accepted_algs: ["ES256"]]
                )
+    end
+
+    test "the FAPI default accepts legacy EdDSA and RFC 9864 Ed25519 only over Ed25519" do
+      key = JOSE.JWK.generate_key({:okp, :Ed25519})
+
+      for alg <- ["EdDSA", "Ed25519"] do
+        jwt = request_object(key, %{}, %{"alg" => alg})
+        trusted = public_jwk(key, %{"alg" => alg})
+
+        assert {:ok, _params} =
+                 RequestObject.verify(jwt, %{"keys" => [trusted]}, base_opts())
+      end
+    end
+
+    test "the FAPI default rejects Ed448 but an explicit non-FAPI policy can opt in" do
+      enable_ed448_support()
+      key = JOSE.JWK.generate_key({:okp, :Ed448})
+
+      for alg <- ["EdDSA", "Ed448"] do
+        jwt = request_object(key, %{}, %{"alg" => alg})
+        trusted = public_jwk(key, %{"alg" => alg})
+
+        assert {:error, :invalid_signature} =
+                 RequestObject.verify(jwt, %{"keys" => [trusted]}, base_opts())
+
+        assert {:error, :invalid_signature} =
+                 RequestObject.verify(
+                   jwt,
+                   %{"keys" => [trusted]},
+                   base_opts() ++ [accepted_algs: [alg], enforce_fapi_alg_policy: true]
+                 )
+
+        assert {:ok, _params} =
+                 RequestObject.verify(
+                   jwt,
+                   %{"keys" => [trusted]},
+                   base_opts() ++ [accepted_algs: [alg]]
+                 )
+      end
+    end
+
+    test "a narrowed FAPI policy retains RSA strength and Edwards curve checks" do
+      weak_rsa = JOSE.JWK.generate_key({:rsa, 1024})
+      weak_rsa_jwt = request_object(weak_rsa, %{}, %{"alg" => "PS256", "typ" => "oauth-authz-req+jwt"})
+      weak_rsa_trusted = public_jwk(weak_rsa, %{"alg" => "PS256"})
+
+      rsa_policy = %{Policy.fapi_message_signing() | accepted_algs: ["PS256"]}
+      rsa_opts = base_opts() ++ Policy.to_verify_opts(rsa_policy)
+
+      assert {:error, :invalid_signature} =
+               RequestObject.verify(weak_rsa_jwt, %{"keys" => [weak_rsa_trusted]}, rsa_opts)
+
+      enable_ed448_support()
+      ed448 = JOSE.JWK.generate_key({:okp, :Ed448})
+      ed448_jwt = request_object(ed448, %{}, %{"alg" => "EdDSA", "typ" => "oauth-authz-req+jwt"})
+      ed448_trusted = public_jwk(ed448, %{"alg" => "EdDSA"})
+
+      edwards_policy = %{Policy.fapi_message_signing() | accepted_algs: ["EdDSA"]}
+      edwards_opts = base_opts() ++ Policy.to_verify_opts(edwards_policy)
+
+      assert {:error, :invalid_signature} =
+               RequestObject.verify(ed448_jwt, %{"keys" => [ed448_trusted]}, edwards_opts)
     end
   end
 
@@ -533,5 +619,11 @@ defmodule Attesto.RequestObjectTest do
     header = %{"alg" => "ES256", "kid" => JOSE.JWK.thumbprint(jwk)}
     {_meta, compact} = jwk |> JOSE.JWS.sign(payload, header) |> JOSE.JWS.compact()
     compact
+  end
+
+  defp enable_ed448_support do
+    previous = JOSE.crypto_fallback()
+    JOSE.crypto_fallback(true)
+    on_exit(fn -> JOSE.crypto_fallback(previous) end)
   end
 end

--- a/test/attesto/signing_alg_test.exs
+++ b/test/attesto/signing_alg_test.exs
@@ -1,0 +1,107 @@
+defmodule Attesto.SigningAlgTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+
+  alias Attesto.SigningAlg
+
+  test "deprecated keyless EdDSA helpers return the Ed25519 profile" do
+    hash_alg = Function.capture(SigningAlg, :hash_alg, 1)
+    hash_half_bytes = Function.capture(SigningAlg, :hash_half_bytes, 1)
+
+    assert hash_alg.("EdDSA") == :sha512
+    assert hash_half_bytes.("EdDSA") == 32
+    assert hash_alg.("Ed25519") == :sha512
+    assert hash_half_bytes.("Ed25519") == 32
+
+    assert_raise ArgumentError, ~r/Ed448 uses SHAKE256/, fn -> hash_alg.("Ed448") end
+    assert_raise ArgumentError, ~r/Ed448 uses SHAKE256/, fn -> hash_half_bytes.("Ed448") end
+  end
+
+  test "legacy and RFC 9864 profiles distinguish Ed25519 fixed hashing from Ed448 XOF hashing" do
+    assert SigningAlg.oidc_hash_profile("EdDSA", ed25519_jwk()) == {:fixed, :sha512, 32}
+    assert SigningAlg.oidc_hash_profile("EdDSA", ed448_jwk()) == {:xof, :shake256, 114, 57}
+    assert SigningAlg.oidc_hash_profile("Ed25519", ed25519_jwk()) == {:fixed, :sha512, 32}
+    assert SigningAlg.oidc_hash_profile("Ed448", ed448_jwk()) == {:xof, :shake256, 114, 57}
+  end
+
+  test "an Ed448 OIDC hash claim contains the left-most 57 bytes" do
+    previous = JOSE.sha3_module()
+    JOSE.sha3_module(:jose_jwa_sha3)
+    on_exit(fn -> JOSE.sha3_module(previous) end)
+
+    encoded = SigningAlg.oidc_hash("ed448-hash-length", "EdDSA", ed448_jwk())
+    assert {:ok, decoded} = Base.url_decode64(encoded, padding: false)
+    assert byte_size(decoded) == 57
+  end
+
+  test "EdDSA profiles reject a non-OKP key and an unsupported OKP curve" do
+    for jwk <- [JOSE.JWK.generate_key({:ec, "P-256"}), x25519_jwk()] do
+      assert_raise ArgumentError, ~r/not compatible with trusted key/, fn ->
+        SigningAlg.oidc_hash_profile("EdDSA", jwk)
+      end
+    end
+  end
+
+  test "explicit identifiers reject the other Edwards curve" do
+    assert_raise ArgumentError, ~r/"Ed25519" is not compatible/, fn ->
+      SigningAlg.validate_for_key!("Ed25519", ed448_jwk())
+    end
+
+    assert_raise ArgumentError, ~r/"Ed448" is not compatible/, fn ->
+      SigningAlg.validate_for_key!("Ed448", ed25519_jwk())
+    end
+  end
+
+  test "the default FAPI policy accepts only the Ed25519 curve" do
+    assert SigningAlg.fapi_compatible?("EdDSA", ed25519_jwk())
+    assert SigningAlg.fapi_compatible?("Ed25519", ed25519_jwk())
+    refute SigningAlg.fapi_compatible?("EdDSA", ed448_jwk())
+    refute SigningAlg.fapi_compatible?("Ed448", ed448_jwk())
+  end
+
+  test "the default FAPI policy requires an RSA modulus of at least 2048 bits" do
+    weak_key = JOSE.JWK.generate_key({:rsa, 1024})
+    compliant_key = JOSE.JWK.generate_key({:rsa, 2048})
+
+    refute SigningAlg.fapi_compatible?("PS256", weak_key)
+    assert SigningAlg.fapi_compatible?("PS256", compliant_key)
+
+    # Key/algorithm validation remains profile-neutral for explicit non-FAPI
+    # policies that intentionally retain compatibility with a weaker key.
+    assert SigningAlg.validate_for_key!("PS256", weak_key) == "PS256"
+  end
+
+  test "missing SHAKE256 support raises a clear configuration error" do
+    previous = JOSE.sha3_module()
+    JOSE.sha3_module(:jose_sha3_unsupported)
+    on_exit(fn -> JOSE.sha3_module(previous) end)
+
+    assert_raise ArgumentError, ~r/require a configured JOSE SHA3 backend with SHAKE256 support/, fn ->
+      SigningAlg.oidc_hash("ed448-needs-shake256", "Ed448", ed448_jwk())
+    end
+  end
+
+  test "Ed448 infers the curve-independent EdDSA JOSE algorithm" do
+    assert SigningAlg.infer(ed448_jwk()) == "EdDSA"
+  end
+
+  test "allowed algorithms include RFC 9864 identifiers while inference remains legacy" do
+    assert "Ed25519" in SigningAlg.allowed()
+    assert "Ed448" in SigningAlg.allowed()
+    assert "Ed25519" in SigningAlg.fapi_algs()
+    refute "Ed448" in SigningAlg.fapi_algs()
+    assert SigningAlg.infer(ed25519_jwk()) == "EdDSA"
+    assert SigningAlg.infer(ed448_jwk()) == "EdDSA"
+  end
+
+  # A correctly sized public member is sufficient to exercise trusted curve
+  # inference without requiring a configured Curve448 signing backend.
+  defp ed25519_jwk, do: okp_jwk("Ed25519", 32)
+  defp ed448_jwk, do: okp_jwk("Ed448", 57)
+  defp x25519_jwk, do: okp_jwk("X25519", 32)
+
+  defp okp_jwk(curve, bytes) do
+    x = :binary.copy(<<1>>, bytes) |> Base.url_encode64(padding: false)
+    JOSE.JWK.from_map(%{"kty" => "OKP", "crv" => curve, "x" => x})
+  end
+end

--- a/test/attesto/test_dpop_test.exs
+++ b/test/attesto/test_dpop_test.exs
@@ -65,6 +65,32 @@ defmodule Attesto.Test.DPoPTest do
       refute Map.has_key?(header["jwk"], "d")
     end
 
+    test "can opt into RFC 9864's explicit Ed25519 identifier" do
+      jwk = JOSE.JWK.generate_key({:okp, :Ed25519})
+      proof = Fixture.proof(jwk, "GET", "https://api.example/x", alg: "Ed25519")
+      [header_b64, _, _] = String.split(proof, ".")
+      header = header_b64 |> Base.url_decode64!(padding: false) |> JSON.decode!()
+
+      assert header["alg"] == "Ed25519"
+
+      assert {:ok, _result} =
+               Attesto.DPoP.verify_proof(proof,
+                 http_method: "GET",
+                 http_uri: "https://api.example/x"
+               )
+    end
+
+    test "algorithm override retains the broader DPoP RSA allowlist" do
+      jwk = JOSE.JWK.generate_key({:rsa, 2048})
+      proof = Fixture.proof(jwk, "GET", "https://api.example/x", alg: "PS384")
+
+      assert {:ok, _result} =
+               Attesto.DPoP.verify_proof(proof,
+                 http_method: "GET",
+                 http_uri: "https://api.example/x"
+               )
+    end
+
     test "binds ath to a presented access token", ctx do
       {token, _} = Fixture.mint_access_token(ctx.config, ctx.principal, ctx.jwk)
 

--- a/test/attesto/token_at_jwt_test.exs
+++ b/test/attesto/token_at_jwt_test.exs
@@ -85,12 +85,13 @@ defmodule Attesto.TokenAtJwtTest do
           {"ES256", {:ec, "P-256"}},
           {"ES384", {:ec, "P-384"}},
           {"ES512", {:ec, "P-521"}},
-          {"EdDSA", :ed25519}
+          {"EdDSA", :ed25519},
+          {"Ed25519", :ed25519}
         ] do
       test "#{alg} mint, verify, and signed-claims inspection agree" do
         alg = unquote(alg)
         pem = signing_pem(unquote(Macro.escape(key)))
-        config_opts = if alg == "PS256", do: [signing_alg: alg], else: []
+        config_opts = if alg in ["PS256", "Ed25519"], do: [signing_alg: alg], else: []
         config = Factory.config(pem, config_opts)
 
         assert {:ok, %{access_token: jwt}} = Token.mint(config, client_principal())
@@ -103,6 +104,20 @@ defmodule Attesto.TokenAtJwtTest do
 
         assert {:ok, signed_claims} = Token.peek_signed_claims(config, jwt)
         assert signed_claims == claims
+      end
+    end
+
+    test "legacy EdDSA and explicit Ed448 access tokens mint and verify over Ed448" do
+      enable_ed448_support()
+      pem = Factory.ed448_pem()
+
+      for alg <- ["EdDSA", "Ed448"] do
+        config_opts = if alg == "Ed448", do: [signing_alg: alg], else: []
+        config = Factory.config(pem, config_opts)
+
+        assert {:ok, %{access_token: jwt}} = Token.mint(config, client_principal())
+        assert %{"alg" => ^alg} = protected_header(jwt)
+        assert {:ok, _claims} = Token.verify(config, jwt)
       end
     end
 
@@ -154,4 +169,10 @@ defmodule Attesto.TokenAtJwtTest do
   defp signing_pem(:rsa), do: Factory.rsa_pem()
   defp signing_pem({:ec, curve}), do: Factory.ec_pem(curve)
   defp signing_pem(:ed25519), do: Factory.ed_pem()
+
+  defp enable_ed448_support do
+    previous = JOSE.crypto_fallback()
+    JOSE.crypto_fallback(true)
+    on_exit(fn -> JOSE.crypto_fallback(previous) end)
+  end
 end

--- a/test/parity/node_parity_test.exs
+++ b/test/parity/node_parity_test.exs
@@ -78,11 +78,12 @@ defmodule Attesto.Parity.NodeParityTest do
     end
   end
 
-  # FAPI 2 mandates PS256 and also permits ES256 / EdDSA (RS256 is excluded).
+  # FAPI 2 mandates PS256 and also permits ES256 / EdDSA over Ed25519 plus
+  # RFC 9864's exact Ed25519 identifier (RS256 and Ed448 are excluded).
   # Prove Attesto mints each of the FAPI signing algorithms to wire that the
   # JS `jose` verifier accepts and decodes identically.
   describe "FAPI algorithm parity (Attesto -> JS jose)" do
-    for alg <- ~w(PS256 ES256 EdDSA) do
+    for alg <- ~w(PS256 ES256 EdDSA Ed25519) do
       test "an Attesto-minted #{alg} token verifies in jose with identical claims",
            %{node_ready: ready} do
         if ready do
@@ -110,6 +111,49 @@ defmodule Attesto.Parity.NodeParityTest do
 
           {:ok, attesto_claims} = Attesto.Token.verify(config, token.access_token)
           assert payload["sub"] == attesto_claims["sub"]
+        end
+      end
+    end
+  end
+
+  # Apply OIDC's generic hash-claim rule to RFC 8032's hash functions and
+  # cross-check the result outside the Elixir/JOSE implementation. Ed448 is
+  # intentionally included here even though FAPI 2 excludes that curve.
+  describe "Edwards OIDC hash parity (Attesto -> Node crypto)" do
+    for {alg, curve} <- [
+          {"EdDSA", "Ed25519"},
+          {"EdDSA", "Ed448"},
+          {"Ed25519", "Ed25519"},
+          {"Ed448", "Ed448"}
+        ] do
+      test "an #{alg}/#{curve} ID Token at_hash matches the independent JS OIDC calculation",
+           %{node_ready: ready} do
+        if ready do
+          alg = unquote(alg)
+          curve = unquote(curve)
+          maybe_enable_ed448(curve)
+          pem = if curve == "Ed448", do: Factory.ed448_pem(), else: Factory.ed_pem()
+          config_opts = if alg in ["Ed25519", "Ed448"], do: [signing_alg: alg], else: []
+          config = Factory.config(pem, config_opts)
+          access_token = "#{String.downcase(alg)}-#{String.downcase(curve)}-reference-access-token"
+
+          assert {:ok, jwt} =
+                   Attesto.IDToken.mint(config, "usr_#{String.downcase(curve)}", "client-#{String.downcase(curve)}",
+                     access_token: access_token
+                   )
+
+          verifier = if alg == "Ed448", do: :verifyEdwardsJwt, else: :verifyJwt
+
+          verifier_args =
+            if alg == "Ed448", do: [jwt, jose_public_pem(pem)], else: [jwt, jose_public_pem(pem), alg]
+
+          %{"payload" => payload, "header" => header} =
+            NodeBridge.call!("attesto_compat", verifier, verifier_args)
+
+          expected = NodeBridge.call!("attesto_compat", :oidcHash, [access_token, alg, curve])
+
+          assert header["alg"] == alg
+          assert payload["at_hash"] == expected
         end
       end
     end
@@ -422,6 +466,7 @@ defmodule Attesto.Parity.NodeParityTest do
   defp alg_pem("PS256"), do: Factory.rsa_pem()
   defp alg_pem("ES256"), do: Factory.ec_pem()
   defp alg_pem("EdDSA"), do: Factory.ed_pem()
+  defp alg_pem("Ed25519"), do: Factory.ed_pem()
 
   defp jose_public_pem(pem) do
     pem
@@ -432,5 +477,13 @@ defmodule Attesto.Parity.NodeParityTest do
       {_meta, public_pem} when is_binary(public_pem) -> public_pem
       public_pem when is_binary(public_pem) -> public_pem
     end
+  end
+
+  defp maybe_enable_ed448("Ed25519"), do: :ok
+
+  defp maybe_enable_ed448("Ed448") do
+    previous = JOSE.crypto_fallback()
+    JOSE.crypto_fallback(true)
+    on_exit(fn -> JOSE.crypto_fallback(previous) end)
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -17,6 +17,9 @@ defmodule Attesto.Test.Factory do
   @doc "A fresh Ed25519 (OKP) signing key PEM -> EdDSA."
   def ed_pem, do: to_pem(JOSE.JWK.generate_key({:okp, :Ed25519}))
 
+  @doc "A fresh Ed448 (OKP) signing key PEM -> EdDSA; requires a JOSE Curve448 backend."
+  def ed448_pem, do: to_pem(JOSE.JWK.generate_key({:okp, :Ed448}))
+
   # JOSE.JWK.to_pem/1 returns {kty_meta, pem} for EC/OKP keys; take the PEM.
   defp to_pem(jwk) do
     case JOSE.JWK.to_pem(jwk) do

--- a/test/support/js/attesto_compat.js
+++ b/test/support/js/attesto_compat.js
@@ -9,8 +9,32 @@ async function jose() {
 async function verifyJwt(token, publicPem, alg) {
   const j = await jose();
   const key = await j.importSPKI(publicPem, alg);
-  const { payload, protectedHeader } = await j.jwtVerify(token, key, { algorithms: [alg] });
+  const { payload, protectedHeader } = await j.jwtVerify(token, key, {
+    algorithms: [alg],
+  });
   return { header: protectedHeader, payload };
+}
+
+// Node's native EdDSA verifier supplies independent RFC 8032 parity for exact
+// RFC 9864 identifiers that jose v5 does not yet accept (notably Ed448).
+function verifyEdwardsJwt(token, publicPem) {
+  const parts = token.split(".");
+  if (parts.length !== 3)
+    throw new TypeError("compact JWT must have three parts");
+
+  const [headerB64, payloadB64, signatureB64] = parts;
+  const signingInput = Buffer.from(`${headerB64}.${payloadB64}`, "ascii");
+  const signature = Buffer.from(signatureB64, "base64url");
+  const key = crypto.createPublicKey(publicPem);
+
+  if (!crypto.verify(null, signingInput, key, signature)) {
+    throw new Error("Edwards JWT signature verification failed");
+  }
+
+  return {
+    header: JSON.parse(Buffer.from(headerB64, "base64url").toString("utf8")),
+    payload: JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")),
+  };
 }
 
 // RFC 7638 JWK thumbprint (SHA-256, base64url, no pad).
@@ -29,6 +53,7 @@ async function signJwt(claims, privatePem, alg, typ) {
 }
 
 module.exports = { verifyJwt, jwkThumbprint, signJwt };
+module.exports.verifyEdwardsJwt = verifyEdwardsJwt;
 
 // Availability probe: resolves to "pong" iff jose loaded.
 async function ping() {
@@ -46,12 +71,37 @@ function x5tS256(derBase64) {
 }
 module.exports.x5tS256 = x5tS256;
 
+// OIDC Core §3.1.3.6 / §3.3.2.11 hash-claim reference.
+function oidcHash(value, alg, crv) {
+  let hash;
+
+  if (["RS256", "PS256", "ES256"].includes(alg)) {
+    hash = crypto.createHash("sha256");
+  } else if (alg === "ES384") {
+    hash = crypto.createHash("sha384");
+  } else if (alg === "ES512") {
+    hash = crypto.createHash("sha512");
+  } else if (["EdDSA", "Ed25519"].includes(alg) && crv === "Ed25519") {
+    hash = crypto.createHash("sha512");
+  } else if (["EdDSA", "Ed448"].includes(alg) && crv === "Ed448") {
+    hash = crypto.createHash("shake256", { outputLength: 114 });
+  } else {
+    throw new TypeError(`unsupported OIDC hash algorithm ${alg}/${crv || ""}`);
+  }
+
+  const digest = hash.update(value, "ascii").digest();
+  return digest.subarray(0, digest.length / 2).toString("base64url");
+}
+module.exports.oidcHash = oidcHash;
+
 // Build an ES256 DPoP proof with a fresh key (embedded public jwk in the
 // header, per RFC 9449) for the inbound leg: a real JS client proof that
 // Attesto.DPoP.verify_proof must accept. Returns {proof, jkt}.
 async function buildDpopProof(htm, htu, iat, jti) {
   const j = await jose();
-  const { publicKey, privateKey } = await j.generateKeyPair("ES256", { extractable: true });
+  const { publicKey, privateKey } = await j.generateKeyPair("ES256", {
+    extractable: true,
+  });
   const publicJwk = await j.exportJWK(publicKey);
   const jkt = await j.calculateJwkThumbprint(publicJwk, "sha256");
   const proof = await new j.SignJWT({ htm, htu, iat, jti })
@@ -81,7 +131,12 @@ function b64urlJson(obj) {
 
 // An unsecured (alg:none) JWT: header.payload. with an empty signature.
 async function signAlgNone(claims, typ) {
-  return b64urlJson({ alg: "none", typ: typ || "JWT" }) + "." + b64urlJson(claims) + ".";
+  return (
+    b64urlJson({ alg: "none", typ: typ || "JWT" }) +
+    "." +
+    b64urlJson(claims) +
+    "."
+  );
 }
 module.exports.signAlgNone = signAlgNone;
 


### PR DESCRIPTION
Closes #11.

## What changed

**Edwards OIDC hash claims.** `at_hash` / `c_hash` for EdDSA-signed ID Tokens were computed with SHA-256 regardless of curve, so they did not interoperate. OIDC's generic rule applied to RFC 8032 gives Ed25519 → SHA-512, left-most 32 bytes; Ed448 → SHAKE256 with 114 bytes of output, left-most 57 bytes. The digest is now selected from the trusted signing key's curve, never the presented JWS header, via new key-aware `SigningAlg.oidc_hash_profile/2` and `oidc_hash/3`. SHAKE256 goes through `JOSE.sha3_module()` so the host's chosen backend is preserved; a missing backend raises a direct configuration error instead of failing obscurely.

**Rotation safety.** ID Token and logout-token minting snapshot `signing_pem()` once, so `alg`, the curve-specific hash, `kid`, and the signature cannot straddle a concurrent keystore rotation.

**Key-bound algorithm policy.** RFC 9864's exact `Ed25519` / `Ed448` identifiers are accepted in keystore metadata, signing, verification, discovery, and DPoP; legacy `EdDSA` inference is retained for wire compatibility. `validate_for_key!/2` rejects trusted metadata that labels a key with an incompatible key type or curve.

**FAPI gates.** Default FAPI policies accept `EdDSA` only over an Ed25519 key, accept exact `Ed25519` but never `Ed448`, and require RSA moduli ≥ 2048 bits. DPoP rejects undersized RSA proof keys across every accepted RSASSA and RSA-PSS algorithm. An explicit non-FAPI `:accepted_algs` list can still opt into Ed448 or a weaker RSA key; a narrowed FAPI policy keeps the key gate via `enforce_fapi_alg_policy: true`. Generic keystore resolution stays profile-neutral.

**Deprecations.** `hash_alg/1` and `hash_half_bytes/1` remain Ed25519-compatible but are deprecated — they cannot express a curve-dependent digest. `Ed448` raises from both.

## Also included

`mix.exs` widens the JOSE requirement from `~> 1.11.12` to `>= 1.11.12 and < 2.0.0` (keeping 1.11.12 as the security/runtime minimum) so hosts can adopt newer native crypto adapters without another Attesto release. Beyond issue #11's scope but kept here deliberately — Neil confirmed the widening rather than splitting it into its own PR. Version cut to 1.3.0.

## Verification

Locally, on the rebased branch:

- `mix test` — 1538 passed (1471 tests, 67 properties)
- `mix test --only parity` — 35 passed (Node `jose` + Python `joserfc` legs both ran, not skipped)
- `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` — all clean

New coverage: Edwards hash claims checked against independent implementations, exact-identifier/curve mismatch rejection, legacy `EdDSA` wire compatibility, FAPI Ed25519-yes / Ed448-no / RSA-<2048-no, DPoP undersized-RSA rejection, and rotation and adversarial cases.
