### PR TITLE
Add opt-in RFC 8252 loopback redirect-URI matching (1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.4.0] - 2026-07-27
+## [1.4.0] - 2026-07-28
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- RFC 8252 §7.3 loopback interface redirection, as an opt-in redirect-URI
+  matching mode. `Attesto.AuthorizationRequest.validate/2` accepts
+  `:redirect_uri_matching`, which is `:exact` (the RFC 6749 §3.1.2.3 simple
+  string comparison) unless a host selects `:exact_allow_loopback_port`. Under
+  the exception a native app's loopback redirect URI matches on any port, so an
+  ephemeral port bound at runtime need not be registered ahead of time, while
+  scheme, host, path, and query still compare exactly. The relaxation is scoped
+  to `http://127.0.0.1/...` and `http://[::1]/...`; RFC 8252 §8.3 makes
+  `http://localhost/...` unacceptable, and `https`, private-use schemes, and
+  every remote host stay exact-match. An unmatched redirect URI is still
+  classified `{:direct, :redirect_uri_not_registered}` and is never used as a
+  redirect target. The new matching logic lives in `Attesto.RedirectURI`.
+
+  Defaults are unchanged: without the option, redirect matching is
+  byte-identical to previous releases. Enabling the exception is incompatible
+  with profiles that mandate exact redirect-URI matching, so it must be a
+  deliberate deployment decision. Redemption-time `redirect_uri` comparison in
+  `Attesto.AuthorizationCode` is unaffected — the code is bound to the URI the
+  client actually presented, ephemeral port included, and still matches exactly.
+
 ## [1.3.0] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] - 2026-07-27
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   classified `{:direct, :redirect_uri_not_registered}` and is never used as a
   redirect target. The new matching logic lives in `Attesto.RedirectURI`.
 
+  The two sides of the comparison differ in one respect: a port on the
+  **request** URI must be decimal `1..65535` or absent, since it names an
+  endpoint a browser is about to be redirected to, while the **registered**
+  URI's port is discarded and so may be anything — including the conventional
+  `:0` placeholder.
+
   Defaults are unchanged: without the option, redirect matching is
   byte-identical to previous releases. Enabling the exception is incompatible
   with profiles that mandate exact redirect-URI matching, so it must be a

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ token, DPoP, and scope checks as Plug modules and adds the MCP-facing
 ```elixir
 def deps do
   [
-    {:attesto, "~> 1.3"}
+    {:attesto, "~> 1.4"}
   ]
 end
 ```
@@ -374,7 +374,7 @@ constraint.
 
 ## Status
 
-A stable `1.x` release: the public API follows [semantic versioning](https://semver.org/) — minor and patch releases are backward-compatible and breaking changes wait for a new major version (read the CHANGELOG before upgrading). Implemented and tested: token issue/verify, DPoP, mTLS certificate-bound tokens, scope, keystore, PKCE validation, JWKS publication, OIDC discovery, the authorization-code grant (single-use, optionally DPoP-bound), refresh-token rotation with reuse detection, token revocation (RFC 7009, refresh-token family), Pushed Authorization Request primitives (RFC 9126), Resource Indicators (RFC 8707), signed request-object policy (JAR) and JARM response signing, token introspection and signed introspection response JWTs, Step-Up Authentication challenges (RFC 9470), the JWT-assertion (`jwt-bearer`) grant, the Device Authorization Grant (RFC 8628), Client-Initiated Backchannel Authentication (CIBA; poll/ping, signed requests per FAPI-CIBA), the RP-Initiated / Back-Channel / Front-Channel Logout and Session Management primitives, RFC 9728 protected-resource metadata, and Client ID Metadata Document (CIMD) verification. The stateful grants run against the `Attesto.CodeStore` / `Attesto.RefreshStore` behaviours, with ETS reference implementations included; a production host implements those over its own database (the atomic-`take` and atomic-`consume` contracts are documented). Cross-language parity tests check Attesto-issued artifacts against a reference implementation in another language. Pin to `~> 1.3`.
+A stable `1.x` release: the public API follows [semantic versioning](https://semver.org/) — minor and patch releases are backward-compatible and breaking changes wait for a new major version (read the CHANGELOG before upgrading). Implemented and tested: token issue/verify, DPoP, mTLS certificate-bound tokens, scope, keystore, PKCE validation, JWKS publication, OIDC discovery, the authorization-code grant (single-use, optionally DPoP-bound), refresh-token rotation with reuse detection, token revocation (RFC 7009, refresh-token family), Pushed Authorization Request primitives (RFC 9126), Resource Indicators (RFC 8707), signed request-object policy (JAR) and JARM response signing, token introspection and signed introspection response JWTs, Step-Up Authentication challenges (RFC 9470), the JWT-assertion (`jwt-bearer`) grant, the Device Authorization Grant (RFC 8628), Client-Initiated Backchannel Authentication (CIBA; poll/ping, signed requests per FAPI-CIBA), the RP-Initiated / Back-Channel / Front-Channel Logout and Session Management primitives, RFC 9728 protected-resource metadata, and Client ID Metadata Document (CIMD) verification. The stateful grants run against the `Attesto.CodeStore` / `Attesto.RefreshStore` behaviours, with ETS reference implementations included; a production host implements those over its own database (the atomic-`take` and atomic-`consume` contracts are documented). Cross-language parity tests check Attesto-issued artifacts against a reference implementation in another language. Pin to `~> 1.4`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ If a decision depends on your business rules, it is yours. If it is a wire-forma
 | RFC 8628 | Device Authorization Grant (`device_code`/`user_code` polling) | Supported (`Attesto.DeviceCode`) |
 | CIBA Core 1.0 | Client-Initiated Backchannel Authentication (poll/ping; signed requests per FAPI-CIBA) | Supported (`Attesto.CIBA`) |
 | RFC 7636 | Proof Key for Code Exchange (PKCE) | Supported (S256) |
+| RFC 8252 §7.3 | OAuth 2.0 for Native Apps — loopback interface redirection (variable port) | Supported, opt-in (`Attesto.RedirectURI`; off by default, redirect matching stays exact) |
 | RFC 8414 | Authorization Server Metadata (discovery) | Supported |
 | RFC 9126 | Pushed Authorization Requests (PAR) — the client pushes the auth request to the AS for a one-time `request_uri`, so request params never ride the browser/URL | Supported (discovery advertisement + request-object primitives; the `request_uri` endpoint/store live in `attesto_phoenix`) |
 | RFC 9728 | Protected Resource Metadata | Supported |

--- a/lib/attesto/authorization_request.ex
+++ b/lib/attesto/authorization_request.ex
@@ -22,7 +22,9 @@ defmodule Attesto.AuthorizationRequest do
   It DOES check `redirect_uri` against the registered set the caller passes in
   `:registered_redirect_uris` by exact string match (RFC 6749 §3.1.2.3, OIDC
   Core §3.1.2.1): the registered set is a fact the host supplies, not a policy
-  decision this module makes.
+  decision this module makes. A caller running the RFC 8252 native-app profile
+  may widen that comparison to the loopback-port exception (§7.3) with
+  `:redirect_uri_matching`; see `Attesto.RedirectURI`.
 
   ## Error disposition (OIDC Core §3.1.2.6, RFC 6749 §4.1.2.1)
 
@@ -47,6 +49,7 @@ defmodule Attesto.AuthorizationRequest do
   """
 
   alias Attesto.PKCE
+  alias Attesto.RedirectURI
   alias Attesto.RequestObject
   alias Attesto.RequestObject.Policy
   alias Attesto.ResourceIndicator
@@ -77,6 +80,11 @@ defmodule Attesto.AuthorizationRequest do
   # RFC 9700 §2.1.1) by passing `require_pkce: false`. Even when relaxed, a
   # `code_challenge` that IS present is still fully enforced (S256, no `plain`).
   @default_require_pkce true
+
+  # RFC 6749 §3.1.2.3: redirect URIs are compared by simple string match. The
+  # RFC 8252 §7.3 loopback exception is opt-in, so an existing deployment sees
+  # byte-identical matching behavior.
+  @default_redirect_uri_matching :exact
 
   @typedoc """
   A normalized, validated authorization request.
@@ -173,6 +181,17 @@ defmodule Attesto.AuthorizationRequest do
       §3.1.2.1). An empty list rejects every request with
       `{:direct, :redirect_uri_not_registered}`.
 
+    * `:redirect_uri_matching` (optional, default `:exact`) - how the request
+      `redirect_uri` is compared against `:registered_redirect_uris`, one of
+      `Attesto.RedirectURI.matching_modes/0`. `:exact` is the RFC 6749
+      §3.1.2.3 simple string comparison. `:exact_allow_loopback_port` adds the
+      RFC 8252 §7.3 exception for native apps, under which a loopback redirect
+      URI (`http://127.0.0.1/...` or `http://[::1]/...`, never
+      `http://localhost/...` - §8.3) matches on any port while scheme, host,
+      path, and query still compare exactly; nothing else is relaxed. Enabling
+      it is a host decision, incompatible with profiles that mandate exact
+      redirect-URI matching. An unrecognized value raises `ArgumentError`.
+
     * `:require_nonce` (optional, default `false`) - the host's OP nonce policy.
       When `true`, an OpenID Connect Authentication Request (one whose EFFECTIVE
       scope - after any signed `request` object is merged - carries `openid`)
@@ -210,12 +229,13 @@ defmodule Attesto.AuthorizationRequest do
   @spec validate(map(), keyword()) :: {:ok, t()} | {:error, error()}
   def validate(params, opts) when is_map(params) and is_list(opts) do
     registered = Keyword.fetch!(opts, :registered_redirect_uris)
+    matching = redirect_uri_matching(opts)
     require_nonce_policy = Keyword.get(opts, :require_nonce, @default_require_nonce)
     require_pkce = Keyword.get(opts, :require_pkce, @default_require_pkce)
 
     with {:ok, params} <- merge_request_object(params, opts),
          {:ok, client_id} <- validate_client_id(params),
-         {:ok, redirect_uri} <- validate_redirect_uri(params, registered) do
+         {:ok, redirect_uri} <- validate_redirect_uri(params, registered, matching) do
       # OIDC Core §3.1.2.1: the nonce requirement applies only to an OpenID
       # Connect Authentication Request, judged on the EFFECTIVE (post-merge)
       # scope. A direct JAR can carry `scope=openid` only inside the signed
@@ -313,7 +333,11 @@ defmodule Attesto.AuthorizationRequest do
   defp redirect_request_object_error(params, error, description, opts) do
     with {:ok, client_id} <- validate_client_id(params),
          {:ok, redirect_uri} <-
-           validate_redirect_uri(params, Keyword.fetch!(opts, :registered_redirect_uris)) do
+           validate_redirect_uri(
+             params,
+             Keyword.fetch!(opts, :registered_redirect_uris),
+             redirect_uri_matching(opts)
+           ) do
       state = string_or_nil(Map.get(params, "state"))
       {:redirect, base} = redirect_error(error, description, redirect_uri, state)
       {:error, {:redirect, Map.merge(base, redirect_error_context(params, client_id))}}
@@ -338,13 +362,25 @@ defmodule Attesto.AuthorizationRequest do
     end
   end
 
+  # The caller's redirect-URI matching policy (RFC 6749 §3.1.2.3, RFC 8252
+  # §7.3). Normalized through `Attesto.RedirectURI.matching!/1` so an
+  # unrecognized value raises rather than silently selecting a policy the host
+  # did not ask for.
+  defp redirect_uri_matching(opts) do
+    opts
+    |> Keyword.get(:redirect_uri_matching, @default_redirect_uri_matching)
+    |> RedirectURI.matching!()
+  end
+
   # RFC 6749 §3.1.2.3 / OIDC Core §3.1.2.1: redirect_uri is REQUIRED for OIDC
-  # and MUST exactly match one of the client's registered URIs. A mismatch is
-  # non-redirectable because the supplied URI is untrusted (OIDC Core §3.1.2.6).
-  defp validate_redirect_uri(params, registered) do
+  # and MUST match one of the client's registered URIs under the caller's
+  # matching policy (exact by default; see `Attesto.RedirectURI`). A mismatch is
+  # non-redirectable because the supplied URI is untrusted (OIDC Core §3.1.2.6):
+  # an unmatched URI is never returned as a redirect target under any policy.
+  defp validate_redirect_uri(params, registered, matching) do
     case Map.get(params, "redirect_uri") do
       uri when is_binary(uri) and uri != "" ->
-        if registered?(uri, registered) do
+        if RedirectURI.registered?(uri, registered, matching) do
           {:ok, uri}
         else
           {:error, {:direct, :redirect_uri_not_registered}}
@@ -356,13 +392,6 @@ defmodule Attesto.AuthorizationRequest do
       _ ->
         {:error, {:direct, :invalid_redirect_uri}}
     end
-  end
-
-  # Exact string comparison (RFC 6749 §3.1.2.3 simple string match). No
-  # normalization, no prefix matching: a registered URI must be reproduced
-  # byte-for-byte, the same discipline AuthorizationCode applies at redemption.
-  defp registered?(uri, registered) when is_list(registered) do
-    Enum.any?(registered, fn candidate -> is_binary(candidate) and candidate == uri end)
   end
 
   # --- Redirectable checks (RFC 6749 §4.1.2.1) ---

--- a/lib/attesto/redirect_uri.ex
+++ b/lib/attesto/redirect_uri.ex
@@ -37,6 +37,14 @@ defmodule Attesto.RedirectURI do
           address are outside the exception;
         * carries no fragment (a redirect URI must not, RFC 6749 §3.1.2).
 
+      The two sides differ in one respect. The **request** URI names an
+      endpoint the server is about to redirect a browser to, so a port it
+      carries must be decimal `1..65535` or absent; an empty
+      (`http://127.0.0.1:/cb`) or out-of-range port is not a reachable endpoint
+      and falls back to exact comparison. The **registered** URI is a pattern
+      whose port is discarded, so any port stands there - including the
+      conventional `:0` placeholder for "an ephemeral port chosen at runtime".
+
       Two loopback URIs match when their scheme, host literal, path, and query
       are all identical; only the port is ignored. IPv4 and IPv6 loopback are
       distinct hosts and never match each other.
@@ -47,11 +55,10 @@ defmodule Attesto.RedirectURI do
 
   ## Registration convention
 
-  Because the port is ignored on both sides, a client registers its loopback
-  redirect URI with whatever port it likes (`http://127.0.0.1/cb`,
-  `http://127.0.0.1:0/cb`, or a fixed port) and any request port matches. Only
-  the port is variable; a request that differs in path or query is still
-  rejected.
+  A client registers its loopback redirect URI with whatever port it likes
+  (`http://127.0.0.1/cb`, `http://127.0.0.1:0/cb`, or a fixed port) and any
+  usable request port then matches. Only the port is variable; a request that
+  differs in path or query is still rejected.
 
   ## Failure is never a redirect
 
@@ -78,8 +85,15 @@ defmodule Attesto.RedirectURI do
   # else. Anchored, so userinfo (`user@127.0.0.1`), a different host, a trailing
   # dot (`127.0.0.1.`), an alternative encoding (`0177.0.0.1`, `[0:0:0:0:0:0:0:1]`),
   # and the hostname `localhost` (§8.3: NOT acceptable) all fail to match and
-  # fall back to exact comparison.
-  @loopback_authority ~r/\A(127\.0\.0\.1|\[::1\])(?::[0-9]*)?\z/
+  # fall back to exact comparison. The port is captured rather than skipped so
+  # `port_allowed?/2` can hold the request side to a usable range.
+  @loopback_authority ~r/\A(127\.0\.0\.1|\[::1\])(?::([0-9]*))?\z/
+
+  # A TCP port a client can actually bind and be redirected to. Port 0 is
+  # excluded on the request side: it is the "pick one for me" placeholder, not
+  # an endpoint a browser can reach.
+  @min_port 1
+  @max_port 65_535
 
   @doc """
   The supported matching modes. Exposed so a caller can validate host
@@ -137,17 +151,17 @@ defmodule Attesto.RedirectURI do
 
   # RFC 8252 §7.3: a loopback request URI matches a registered loopback URI
   # whose scheme, host literal, path, and query are identical. `nil` from
-  # `loopback_identity/1` means "not a loopback redirect URI", which never
+  # `loopback_identity/2` means "not a loopback redirect URI", which never
   # matches anything - including another non-loopback URI, since the request
   # side is checked first and short-circuits.
   defp loopback?(uri, registered) do
-    case loopback_identity(uri) do
+    case loopback_identity(uri, :request) do
       nil ->
         false
 
       identity ->
         Enum.any?(registered, fn candidate ->
-          is_binary(candidate) and loopback_identity(candidate) == identity
+          is_binary(candidate) and loopback_identity(candidate, :registered) == identity
         end)
     end
   end
@@ -157,18 +171,41 @@ defmodule Attesto.RedirectURI do
   # distinguishes one redirect target from another (host literal, path, query)
   # is carried, so two URIs share an identity only when they differ solely in
   # port.
-  defp loopback_identity(uri) do
+  #
+  # `role` distinguishes the two sides, which are not symmetric in what a port
+  # may be. The REQUEST URI names an endpoint the authorization server is about
+  # to redirect a browser to, so a port it carries must be one a client can
+  # actually listen on: absent, or decimal 1-65535. An empty port
+  # (`http://127.0.0.1:/cb`) or an out-of-range one
+  # (`http://127.0.0.1:999999999/cb`) is not a reachable endpoint and falls back
+  # to exact comparison rather than being minted a redirect target.
+  #
+  # The REGISTERED URI is a pattern, never a target: its port is discarded by
+  # construction, so any port stands. That is deliberate - `:0` is the
+  # conventional placeholder for "an ephemeral port chosen at runtime", and
+  # rejecting it would break the natural way to register a loopback callback.
+  defp loopback_identity(uri, role) do
     if String.starts_with?(uri, @http_scheme_prefix) do
-      uri |> URI.parse() |> identity()
+      uri |> URI.parse() |> identity(role)
     end
   end
 
-  defp identity(%URI{authority: authority, path: path, query: query, fragment: nil}) when is_binary(authority) do
+  defp identity(%URI{authority: authority, path: path, query: query, fragment: nil}, role) when is_binary(authority) do
     case Regex.run(@loopback_authority, authority) do
       [_authority, host] -> {host, path, query}
+      [_authority, host, port] -> if port_allowed?(port, role), do: {host, path, query}
       nil -> nil
     end
   end
 
-  defp identity(%URI{}), do: nil
+  defp identity(%URI{}, _role), do: nil
+
+  defp port_allowed?(_port, :registered), do: true
+
+  defp port_allowed?(port, :request) do
+    case Integer.parse(port) do
+      {number, ""} -> number in @min_port..@max_port
+      _ -> false
+    end
+  end
 end

--- a/lib/attesto/redirect_uri.ex
+++ b/lib/attesto/redirect_uri.ex
@@ -1,0 +1,174 @@
+defmodule Attesto.RedirectURI do
+  @moduledoc """
+  Redirect-URI matching for the authorization endpoint (RFC 6749 §3.1.2.3,
+  RFC 8252 §7.3).
+
+  RFC 6749 §3.1.2.3 matches a request `redirect_uri` against the client's
+  registered set by **simple string comparison**: byte-for-byte, no
+  normalization and no prefix matching. That is the default here, and it is what
+  the OpenID Connect and FAPI profiles assume.
+
+  RFC 8252 (BCP 212) defines one narrow exception. A native application that
+  cannot use a private-use URI scheme (§7.1) instead binds an ephemeral port on
+  the loopback interface (§7.3) and only learns that port at runtime, so the
+  port cannot be registered ahead of time. §7.3 therefore requires the
+  authorization server to "allow any port to be specified at the time of the
+  request for loopback IP redirect URIs", while comparing the rest of the URI
+  exactly.
+
+  ## Matching modes
+
+    * `:exact` (default) - RFC 6749 §3.1.2.3 simple string comparison, and
+      nothing else.
+
+    * `:exact_allow_loopback_port` - exact comparison first; failing that, the
+      RFC 8252 §7.3 loopback exception. The exception applies only when BOTH the
+      request URI and the registered URI are loopback redirect URIs, meaning
+      each one:
+
+        * begins with the byte-exact scheme `http://` (an `https` URI, a
+          private-use scheme, and an upper-case `HTTP://` are all outside the
+          exception and stay exact-match);
+        * has an authority of exactly `127.0.0.1` or `[::1]`, optionally
+          followed by `:<port>` and nothing else. RFC 8252 §8.3 is explicit that
+          the literal IP address is required and the hostname `localhost` is NOT
+          acceptable, so `http://localhost:PORT/...` never matches. Any
+          userinfo, any other host, and any other spelling of the loopback
+          address are outside the exception;
+        * carries no fragment (a redirect URI must not, RFC 6749 §3.1.2).
+
+      Two loopback URIs match when their scheme, host literal, path, and query
+      are all identical; only the port is ignored. IPv4 and IPv6 loopback are
+      distinct hosts and never match each other.
+
+  Enabling the exception is a deliberate deployment decision: a profile that
+  mandates exact redirect-URI matching forbids it. It is off by default so the
+  matching behavior is unchanged unless a host asks for it.
+
+  ## Registration convention
+
+  Because the port is ignored on both sides, a client registers its loopback
+  redirect URI with whatever port it likes (`http://127.0.0.1/cb`,
+  `http://127.0.0.1:0/cb`, or a fixed port) and any request port matches. Only
+  the port is variable; a request that differs in path or query is still
+  rejected.
+
+  ## Failure is never a redirect
+
+  This module answers a boolean. A request URI that matches nothing is not a
+  trusted redirect target, and the caller MUST report the failure directly to
+  the user agent rather than redirecting to the supplied URI (OIDC Core
+  §3.1.2.6) - otherwise the endpoint is an open redirect.
+  """
+
+  @typedoc "The redirect-URI matching mode (see the moduledoc)."
+  @type matching :: :exact | :exact_allow_loopback_port
+
+  @matching_modes [:exact, :exact_allow_loopback_port]
+
+  # RFC 8252 §7.3 covers only `http` on the loopback interface: the connection
+  # never leaves the device, so TLS is neither available nor required there.
+  # Compared as a byte-exact prefix rather than through the parsed scheme, so
+  # the exception cannot be reached by a case variant the exact-match rule would
+  # otherwise have rejected.
+  @http_scheme_prefix "http://"
+
+  # RFC 8252 §7.3 / §8.3: the authority of a loopback redirect URI is the
+  # literal IPv4 or IPv6 loopback address with an optional port, and nothing
+  # else. Anchored, so userinfo (`user@127.0.0.1`), a different host, a trailing
+  # dot (`127.0.0.1.`), an alternative encoding (`0177.0.0.1`, `[0:0:0:0:0:0:0:1]`),
+  # and the hostname `localhost` (§8.3: NOT acceptable) all fail to match and
+  # fall back to exact comparison.
+  @loopback_authority ~r/\A(127\.0\.0\.1|\[::1\])(?::[0-9]*)?\z/
+
+  @doc """
+  The supported matching modes. Exposed so a caller can validate host
+  configuration against the same list this module enforces.
+  """
+  @spec matching_modes() :: [matching()]
+  def matching_modes, do: @matching_modes
+
+  @doc """
+  Normalize a caller-supplied matching mode, raising `ArgumentError` on an
+  unrecognized value.
+
+  A misspelled mode must never silently degrade into a different matching
+  policy, in either direction: quietly falling back to `:exact` would hide a
+  host's deliberate opt-in, and quietly enabling anything else would relax
+  matching nobody asked for. Raising makes the misconfiguration visible.
+  """
+  @spec matching!(term()) :: matching()
+  def matching!(matching) when matching in @matching_modes, do: matching
+
+  def matching!(other) do
+    raise ArgumentError,
+          "invalid redirect_uri matching mode #{inspect(other)}; expected one of #{inspect(@matching_modes)}"
+  end
+
+  @doc """
+  Whether `uri` matches one of the client's `registered` redirect URIs under
+  `matching` (RFC 6749 §3.1.2.3, RFC 8252 §7.3).
+
+  A non-binary entry in `registered` is ignored rather than raising: the
+  registered set comes from the host, and one malformed entry must not make an
+  otherwise valid request crash the endpoint.
+  """
+  @spec registered?(String.t(), [String.t()], matching()) :: boolean()
+  def registered?(uri, registered, matching \\ :exact)
+
+  def registered?(uri, registered, :exact) when is_binary(uri) and is_list(registered) do
+    exact?(uri, registered)
+  end
+
+  def registered?(uri, registered, :exact_allow_loopback_port) when is_binary(uri) and is_list(registered) do
+    # RFC 8252 §7.3 is an exception applied only after the RFC 6749 §3.1.2.3
+    # comparison has already failed, so enabling it can never change the outcome
+    # of a request that matched exactly.
+    exact?(uri, registered) or loopback?(uri, registered)
+  end
+
+  # Exact string comparison (RFC 6749 §3.1.2.3 simple string match). No
+  # normalization, no prefix matching: a registered URI must be reproduced
+  # byte-for-byte, the same discipline `Attesto.AuthorizationCode` applies to
+  # the redemption-time `redirect_uri` check.
+  defp exact?(uri, registered) do
+    Enum.any?(registered, fn candidate -> is_binary(candidate) and candidate == uri end)
+  end
+
+  # RFC 8252 §7.3: a loopback request URI matches a registered loopback URI
+  # whose scheme, host literal, path, and query are identical. `nil` from
+  # `loopback_identity/1` means "not a loopback redirect URI", which never
+  # matches anything - including another non-loopback URI, since the request
+  # side is checked first and short-circuits.
+  defp loopback?(uri, registered) do
+    case loopback_identity(uri) do
+      nil ->
+        false
+
+      identity ->
+        Enum.any?(registered, fn candidate ->
+          is_binary(candidate) and loopback_identity(candidate) == identity
+        end)
+    end
+  end
+
+  # The port-independent identity of a loopback redirect URI, or `nil` when the
+  # URI is not one. The port is the only component omitted; everything else that
+  # distinguishes one redirect target from another (host literal, path, query)
+  # is carried, so two URIs share an identity only when they differ solely in
+  # port.
+  defp loopback_identity(uri) do
+    if String.starts_with?(uri, @http_scheme_prefix) do
+      uri |> URI.parse() |> identity()
+    end
+  end
+
+  defp identity(%URI{authority: authority, path: path, query: query, fragment: nil}) when is_binary(authority) do
+    case Regex.run(@loopback_authority, authority) do
+      [_authority, host] -> {host, path, query}
+      nil -> nil
+    end
+  end
+
+  defp identity(%URI{}), do: nil
+end

--- a/lib/attesto/redirect_uri.ex
+++ b/lib/attesto/redirect_uri.ex
@@ -30,11 +30,24 @@ defmodule Attesto.RedirectURI do
           private-use scheme, and an upper-case `HTTP://` are all outside the
           exception and stay exact-match);
         * has an authority of exactly `127.0.0.1` or `[::1]`, optionally
-          followed by `:<port>` and nothing else. RFC 8252 §8.3 is explicit that
-          the literal IP address is required and the hostname `localhost` is NOT
-          acceptable, so `http://localhost:PORT/...` never matches. Any
-          userinfo, any other host, and any other spelling of the loopback
-          address are outside the exception;
+          followed by `:<port>` and nothing else. Any userinfo, any other host,
+          and any other spelling of the loopback address are outside the
+          exception.
+
+          `localhost` is deliberately excluded. RFC 8252 §8.3 makes the literal
+          IP preferable precisely because `localhost` is a *name*, resolved by
+          the device's host-name configuration, and so is not guaranteed to be
+          the loopback interface. Extending port flexibility to a name whose
+          resolution the server cannot reason about would widen the exception
+          past what §7.3 asks for, so `http://localhost:PORT/...` never matches
+          under it.
+
+          This scopes the exception, not registration: a client that has
+          registered a `localhost` redirect URI still reaches it by exact
+          match, since that URI is one the host deliberately registered and
+          §8.3's "NOT RECOMMENDED" is guidance to the client about which URI to
+          choose, not a requirement that the server refuse it. Such a client
+          simply gets no port flexibility;
         * carries no fragment (a redirect URI must not, RFC 6749 §3.1.2).
 
       The two sides differ in one respect. The **request** URI names an

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.3.0"
+  @version "1.4.0"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 

--- a/test/attesto/authorization_request_loopback_redirect_test.exs
+++ b/test/attesto/authorization_request_loopback_redirect_test.exs
@@ -1,0 +1,202 @@
+defmodule Attesto.AuthorizationRequestLoopbackRedirectTest do
+  @moduledoc """
+  RFC 8252 §7.3 loopback interface redirection, exercised through the public
+  `Attesto.AuthorizationRequest.validate/2` surface.
+
+  Every case is run in both configurations - the default `:exact` and the opt-in
+  `:exact_allow_loopback_port` - because the guarantee under test is as much
+  "nothing changes unless the host asks for it" as it is "the loopback port
+  varies when it does".
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Attesto.AuthorizationRequest
+
+  # BASE64URL(SHA256(verifier)), 43 chars, no padding (RFC 7636 §4.2).
+  @code_challenge "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+  defp params(redirect_uri) do
+    %{
+      "response_type" => "code",
+      "client_id" => "native-client",
+      "redirect_uri" => redirect_uri,
+      "scope" => "openid",
+      "state" => "xyz",
+      "code_challenge" => @code_challenge,
+      "code_challenge_method" => "S256"
+    }
+  end
+
+  defp validate(redirect_uri, registered, opts \\ []) do
+    AuthorizationRequest.validate(
+      params(redirect_uri),
+      [registered_redirect_uris: registered] ++ opts
+    )
+  end
+
+  defp validate_exact(redirect_uri, registered) do
+    validate(redirect_uri, registered, redirect_uri_matching: :exact)
+  end
+
+  defp validate_loopback(redirect_uri, registered) do
+    validate(redirect_uri, registered, redirect_uri_matching: :exact_allow_loopback_port)
+  end
+
+  describe "default matching (RFC 6749 §3.1.2.3)" do
+    test "is exact when no :redirect_uri_matching option is passed" do
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate("http://127.0.0.1:51823/cb", ["http://127.0.0.1:0/cb"])
+    end
+
+    test "raises on an unrecognized matching mode rather than picking one" do
+      assert_raise ArgumentError, ~r/invalid redirect_uri matching mode/, fn ->
+        validate("http://127.0.0.1:51823/cb", ["http://127.0.0.1:0/cb"], redirect_uri_matching: :loopback)
+      end
+    end
+  end
+
+  describe "exact match (both configurations)" do
+    test "an exact match still wins when the loopback rule is enabled" do
+      registered = ["https://app.example/cb"]
+
+      assert {:ok, request} = validate_loopback("https://app.example/cb", registered)
+      assert request.redirect_uri == "https://app.example/cb"
+
+      assert {:ok, request} = validate_exact("https://app.example/cb", registered)
+      assert request.redirect_uri == "https://app.example/cb"
+    end
+
+    test "an exactly matching loopback URI is accepted in both configurations" do
+      registered = ["http://127.0.0.1:51823/cb"]
+
+      assert {:ok, _request} = validate_exact("http://127.0.0.1:51823/cb", registered)
+      assert {:ok, _request} = validate_loopback("http://127.0.0.1:51823/cb", registered)
+    end
+  end
+
+  describe "loopback interface redirection (RFC 8252 §7.3)" do
+    test "an IPv4 loopback request matches the registered URI on a different port" do
+      assert {:ok, request} = validate_loopback("http://127.0.0.1:51823/cb", ["http://127.0.0.1:0/cb"])
+
+      # The validated request carries the URI the client actually asked for -
+      # the ephemeral port the app is listening on - not the registered one.
+      assert request.redirect_uri == "http://127.0.0.1:51823/cb"
+    end
+
+    test "the same request is rejected with the rule off" do
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_exact("http://127.0.0.1:51823/cb", ["http://127.0.0.1:0/cb"])
+    end
+
+    test "an IPv6 loopback request behaves identically to the IPv4 case" do
+      assert {:ok, request} = validate_loopback("http://[::1]:51823/cb", ["http://[::1]:0/cb"])
+      assert request.redirect_uri == "http://[::1]:51823/cb"
+
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_exact("http://[::1]:51823/cb", ["http://[::1]:0/cb"])
+    end
+
+    test "a portless registration also matches any request port" do
+      assert {:ok, _request} = validate_loopback("http://127.0.0.1:51823/cb", ["http://127.0.0.1/cb"])
+      assert {:ok, _request} = validate_loopback("http://[::1]:51823/cb", ["http://[::1]/cb"])
+    end
+
+    # RFC 8252 §8.3: `localhost` is NOT acceptable - the literal IP is required.
+    test "localhost is rejected in all configurations" do
+      for registered <- [["http://127.0.0.1:0/cb"], ["http://localhost:0/cb"]] do
+        assert {:error, {:direct, :redirect_uri_not_registered}} =
+                 validate_loopback("http://localhost:51823/cb", registered)
+
+        assert {:error, {:direct, :redirect_uri_not_registered}} =
+                 validate_exact("http://localhost:51823/cb", registered)
+      end
+    end
+
+    test "a differing path is rejected even when scheme and host match" do
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_loopback("http://127.0.0.1:51823/other", ["http://127.0.0.1:0/cb"])
+    end
+
+    test "a differing query is rejected" do
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_loopback("http://127.0.0.1:51823/cb?a=2", ["http://127.0.0.1:0/cb?a=1"])
+    end
+
+    test "https loopback is not relaxed" do
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_loopback("https://127.0.0.1:51823/cb", ["https://127.0.0.1:0/cb"])
+    end
+
+    test "a remote host is not relaxed" do
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_loopback("https://example.com:8443/cb", ["https://example.com:443/cb"])
+    end
+
+    test "a private-use URI scheme redirect is unaffected in both configurations" do
+      registered = ["com.example.app:/cb"]
+
+      assert {:ok, _request} = validate_exact("com.example.app:/cb", registered)
+      assert {:ok, _request} = validate_loopback("com.example.app:/cb", registered)
+
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_loopback("com.example.app:/other", registered)
+    end
+
+    test "the loopback rule also governs the request-object error path" do
+      # A request object that cannot be verified is only reportable BY REDIRECT
+      # once the redirect_uri is trusted (OIDC Core §3.1.2.6). Reaching the
+      # redirect classification proves the loopback URI was matched there too.
+      params = Map.put(params("http://127.0.0.1:51823/cb"), "request", "not-a-jwt")
+
+      assert {:error, {:redirect, error}} =
+               AuthorizationRequest.validate(params,
+                 registered_redirect_uris: ["http://127.0.0.1:0/cb"],
+                 redirect_uri_matching: :exact_allow_loopback_port
+               )
+
+      assert error.error == "invalid_request_object"
+      assert error.redirect_uri == "http://127.0.0.1:51823/cb"
+
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               AuthorizationRequest.validate(params,
+                 registered_redirect_uris: ["http://127.0.0.1:0/cb"],
+                 redirect_uri_matching: :exact
+               )
+    end
+  end
+
+  describe "open-redirect regression" do
+    # An unmatched redirect_uri must always be classified as a DIRECT error, so
+    # the transport has no validated URI to redirect to. If any of these leaked
+    # a `{:redirect, _}`, the endpoint would be an open redirect.
+    test "an unregistered host is never returned as a redirect target" do
+      registered = ["http://127.0.0.1:0/cb", "https://app.example/cb"]
+
+      for uri <- [
+            "https://evil.example/cb",
+            "http://evil.example:51823/cb",
+            "http://127.0.0.1:51823@evil.example/cb",
+            "http://evil.example@127.0.0.1:51823/cb",
+            "http://localhost:51823/cb",
+            "http://0177.0.0.1:51823/cb",
+            "http://2130706433:51823/cb",
+            "http://127.0.0.2:51823/cb",
+            "http://[::1]:51823/cb",
+            "https://127.0.0.1:51823/cb",
+            "HTTP://127.0.0.1:51823/cb"
+          ] do
+        assert {:error, {:direct, :redirect_uri_not_registered}} = validate_loopback(uri, registered),
+               "#{uri} must not be trusted as a redirect target"
+
+        assert {:error, {:direct, :redirect_uri_not_registered}} = validate_exact(uri, registered),
+               "#{uri} must not be trusted as a redirect target"
+      end
+    end
+
+    test "an empty registered set rejects every redirect URI" do
+      assert {:error, {:direct, :redirect_uri_not_registered}} =
+               validate_loopback("http://127.0.0.1:51823/cb", [])
+    end
+  end
+end

--- a/test/attesto/redirect_uri_test.exs
+++ b/test/attesto/redirect_uri_test.exs
@@ -1,0 +1,240 @@
+defmodule Attesto.RedirectURITest do
+  use ExUnit.Case, async: true
+
+  alias Attesto.RedirectURI
+
+  describe "matching_modes/0" do
+    test "lists exactly the modes registered?/3 accepts" do
+      assert RedirectURI.matching_modes() == [:exact, :exact_allow_loopback_port]
+    end
+  end
+
+  describe "matching!/1" do
+    test "passes a supported mode through" do
+      assert RedirectURI.matching!(:exact) == :exact
+      assert RedirectURI.matching!(:exact_allow_loopback_port) == :exact_allow_loopback_port
+    end
+
+    test "raises on an unrecognized mode rather than silently picking a policy" do
+      assert_raise ArgumentError, ~r/invalid redirect_uri matching mode :loopback/, fn ->
+        RedirectURI.matching!(:loopback)
+      end
+
+      assert_raise ArgumentError, fn -> RedirectURI.matching!(nil) end
+      assert_raise ArgumentError, fn -> RedirectURI.matching!("exact") end
+    end
+  end
+
+  describe "registered?/3 with :exact (RFC 6749 §3.1.2.3)" do
+    test "matches byte-for-byte" do
+      assert RedirectURI.registered?("https://app.example/cb", ["https://app.example/cb"], :exact)
+    end
+
+    test "defaults to :exact when no mode is given" do
+      assert RedirectURI.registered?("https://app.example/cb", ["https://app.example/cb"])
+      refute RedirectURI.registered?("https://app.example/cb", ["https://app.example/cb/"])
+    end
+
+    test "does not normalize case, trailing slash, or default ports" do
+      registered = ["https://app.example/cb"]
+
+      refute RedirectURI.registered?("https://APP.example/cb", registered, :exact)
+      refute RedirectURI.registered?("https://app.example/cb/", registered, :exact)
+      refute RedirectURI.registered?("https://app.example:443/cb", registered, :exact)
+    end
+
+    test "an empty registered set matches nothing" do
+      refute RedirectURI.registered?("https://app.example/cb", [], :exact)
+    end
+
+    test "ignores a non-binary registered entry instead of raising" do
+      assert RedirectURI.registered?("https://app.example/cb", [nil, :atom, "https://app.example/cb"], :exact)
+      refute RedirectURI.registered?("https://app.example/cb", [nil, :atom], :exact)
+    end
+
+    test "never applies the loopback exception" do
+      refute RedirectURI.registered?("http://127.0.0.1:51823/cb", ["http://127.0.0.1:0/cb"], :exact)
+      refute RedirectURI.registered?("http://[::1]:51823/cb", ["http://[::1]/cb"], :exact)
+    end
+  end
+
+  describe "registered?/3 with :exact_allow_loopback_port (RFC 8252 §7.3)" do
+    test "an exact match still wins" do
+      assert RedirectURI.registered?(
+               "https://app.example/cb",
+               ["https://app.example/cb"],
+               :exact_allow_loopback_port
+             )
+    end
+
+    test "an IPv4 loopback request matches any registered loopback port" do
+      for registered <- ["http://127.0.0.1:0/cb", "http://127.0.0.1/cb", "http://127.0.0.1:8080/cb"] do
+        assert RedirectURI.registered?("http://127.0.0.1:51823/cb", [registered], :exact_allow_loopback_port),
+               "expected #{registered} to match a request on port 51823"
+      end
+    end
+
+    test "an IPv6 loopback request behaves identically to the IPv4 case" do
+      for registered <- ["http://[::1]:0/cb", "http://[::1]/cb", "http://[::1]:8080/cb"] do
+        assert RedirectURI.registered?("http://[::1]:51823/cb", [registered], :exact_allow_loopback_port),
+               "expected #{registered} to match a request on port 51823"
+      end
+    end
+
+    test "IPv4 and IPv6 loopback are distinct hosts" do
+      refute RedirectURI.registered?("http://[::1]:51823/cb", ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
+      refute RedirectURI.registered?("http://127.0.0.1:51823/cb", ["http://[::1]:0/cb"], :exact_allow_loopback_port)
+    end
+
+    test "the path must still match exactly" do
+      registered = ["http://127.0.0.1:0/cb"]
+
+      refute RedirectURI.registered?("http://127.0.0.1:51823/other", registered, :exact_allow_loopback_port)
+      refute RedirectURI.registered?("http://127.0.0.1:51823/cb/", registered, :exact_allow_loopback_port)
+      refute RedirectURI.registered?("http://127.0.0.1:51823/cb/sub", registered, :exact_allow_loopback_port)
+      refute RedirectURI.registered?("http://127.0.0.1:51823", registered, :exact_allow_loopback_port)
+    end
+
+    test "the query must still match exactly" do
+      refute RedirectURI.registered?(
+               "http://127.0.0.1:51823/cb?a=2",
+               ["http://127.0.0.1:0/cb?a=1"],
+               :exact_allow_loopback_port
+             )
+
+      refute RedirectURI.registered?(
+               "http://127.0.0.1:51823/cb",
+               ["http://127.0.0.1:0/cb?a=1"],
+               :exact_allow_loopback_port
+             )
+
+      assert RedirectURI.registered?(
+               "http://127.0.0.1:51823/cb?a=1",
+               ["http://127.0.0.1:0/cb?a=1"],
+               :exact_allow_loopback_port
+             )
+    end
+
+    # RFC 8252 §8.3: the literal IP address is required; `localhost` is NOT
+    # acceptable, because any application on the device may claim the name.
+    test "localhost is rejected in every form" do
+      for uri <- ["http://localhost:51823/cb", "http://localhost/cb"] do
+        refute RedirectURI.registered?(uri, ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
+        refute RedirectURI.registered?(uri, ["http://localhost:0/cb"], :exact_allow_loopback_port)
+        refute RedirectURI.registered?("http://127.0.0.1:51823/cb", [uri], :exact_allow_loopback_port)
+      end
+
+      # A registered `localhost` URI is still reachable by exact match; it just
+      # gets no port flexibility.
+      assert RedirectURI.registered?(
+               "http://localhost:51823/cb",
+               ["http://localhost:51823/cb"],
+               :exact_allow_loopback_port
+             )
+    end
+
+    test "https loopback is not relaxed" do
+      refute RedirectURI.registered?(
+               "https://127.0.0.1:51823/cb",
+               ["https://127.0.0.1:0/cb"],
+               :exact_allow_loopback_port
+             )
+
+      refute RedirectURI.registered?("https://[::1]:51823/cb", ["https://[::1]:0/cb"], :exact_allow_loopback_port)
+    end
+
+    test "a remote host is not relaxed" do
+      refute RedirectURI.registered?(
+               "https://example.com:8443/cb",
+               ["https://example.com:443/cb"],
+               :exact_allow_loopback_port
+             )
+
+      refute RedirectURI.registered?(
+               "http://example.com:8443/cb",
+               ["http://example.com/cb"],
+               :exact_allow_loopback_port
+             )
+    end
+
+    test "a private-use URI scheme redirect is unaffected" do
+      registered = ["com.example.app:/cb"]
+
+      assert RedirectURI.registered?("com.example.app:/cb", registered, :exact_allow_loopback_port)
+      assert RedirectURI.registered?("com.example.app:/cb", registered, :exact)
+      refute RedirectURI.registered?("com.example.app:/other", registered, :exact_allow_loopback_port)
+    end
+
+    # The exception is keyed on the byte-exact `http://` prefix, so a scheme
+    # spelled differently is outside it and stays exact-match.
+    test "an upper-case scheme is outside the exception" do
+      refute RedirectURI.registered?("HTTP://127.0.0.1:51823/cb", ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
+      refute RedirectURI.registered?("http://127.0.0.1:51823/cb", ["HTTP://127.0.0.1:0/cb"], :exact_allow_loopback_port)
+    end
+
+    test "userinfo takes the URI outside the exception" do
+      refute RedirectURI.registered?(
+               "http://evil.example@127.0.0.1:51823/cb",
+               ["http://127.0.0.1:0/cb"],
+               :exact_allow_loopback_port
+             )
+
+      # The authority here parses as userinfo `127.0.0.1:51823` on host
+      # `evil.example`; the loopback literal appearing in the string must not
+      # buy any relaxation.
+      refute RedirectURI.registered?(
+               "http://127.0.0.1:51823@evil.example/cb",
+               ["http://127.0.0.1:0/cb"],
+               :exact_allow_loopback_port
+             )
+    end
+
+    test "an alternative spelling of the loopback address is outside the exception" do
+      registered = ["http://127.0.0.1:0/cb"]
+
+      for uri <- [
+            "http://0177.0.0.1:51823/cb",
+            "http://2130706433:51823/cb",
+            "http://127.0.0.1.:51823/cb",
+            "http://127.0.0.2:51823/cb",
+            "http://127.1:51823/cb",
+            "http://[0:0:0:0:0:0:0:1]:51823/cb"
+          ] do
+        refute RedirectURI.registered?(uri, registered, :exact_allow_loopback_port),
+               "expected #{uri} to fall outside the RFC 8252 §7.3 exception"
+      end
+
+      refute RedirectURI.registered?(
+               "http://[::1]:51823/cb",
+               ["http://[0:0:0:0:0:0:0:1]:0/cb"],
+               :exact_allow_loopback_port
+             )
+    end
+
+    test "a fragment takes the URI outside the exception" do
+      refute RedirectURI.registered?(
+               "http://127.0.0.1:51823/cb#f",
+               ["http://127.0.0.1:0/cb"],
+               :exact_allow_loopback_port
+             )
+
+      refute RedirectURI.registered?(
+               "http://127.0.0.1:51823/cb",
+               ["http://127.0.0.1:0/cb#f"],
+               :exact_allow_loopback_port
+             )
+    end
+
+    test "a malformed port takes the URI outside the exception" do
+      refute RedirectURI.registered?("http://127.0.0.1:abc/cb", ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
+    end
+
+    test "an empty registered set still matches nothing" do
+      refute RedirectURI.registered?("http://127.0.0.1:51823/cb", [], :exact_allow_loopback_port)
+    end
+
+    test "a non-loopback request never matches a loopback registration" do
+      refute RedirectURI.registered?("https://evil.example/cb", ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
+    end
+  end
+end

--- a/test/attesto/redirect_uri_test.exs
+++ b/test/attesto/redirect_uri_test.exs
@@ -229,6 +229,49 @@ defmodule Attesto.RedirectURITest do
       refute RedirectURI.registered?("http://127.0.0.1:abc/cb", ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
     end
 
+    # The request URI is a redirect TARGET, so a port it carries must be one a
+    # client can actually listen on. An unusable port is not minted into a
+    # Location header just because the rest of the URI looks like loopback.
+    test "a request port outside 1..65535 takes the URI outside the exception" do
+      # Registered with a port none of the refused URIs reproduce, so an exact
+      # match cannot rescue them and only the exception is under test.
+      registered = ["http://127.0.0.1:8080/cb"]
+
+      for uri <- [
+            "http://127.0.0.1:/cb",
+            "http://127.0.0.1:0/cb",
+            "http://127.0.0.1:65536/cb",
+            "http://127.0.0.1:999999999999999999999/cb"
+          ] do
+        refute RedirectURI.registered?(uri, registered, :exact_allow_loopback_port),
+               "expected request port in #{uri} to be refused"
+      end
+
+      # The boundaries themselves are usable.
+      assert RedirectURI.registered?("http://127.0.0.1:1/cb", registered, :exact_allow_loopback_port)
+      assert RedirectURI.registered?("http://127.0.0.1:65535/cb", registered, :exact_allow_loopback_port)
+    end
+
+    # The registered URI is a pattern, never a target: its port is discarded, so
+    # the `:0` placeholder convention keeps working.
+    test "the registered side accepts any port, including the :0 placeholder" do
+      for registered <- ["http://127.0.0.1:0/cb", "http://127.0.0.1:/cb", "http://127.0.0.1:99999999/cb"] do
+        assert RedirectURI.registered?("http://127.0.0.1:51823/cb", [registered], :exact_allow_loopback_port),
+               "expected registered #{registered} to still match a usable request port"
+      end
+    end
+
+    # `http://127.0.0.1:0/cb` as a REQUEST is refused by the exception, but an
+    # exact registration of it still matches exactly - the exception only ever
+    # adds matches.
+    test "an exact match still wins for a request port the exception would refuse" do
+      assert RedirectURI.registered?(
+               "http://127.0.0.1:0/cb",
+               ["http://127.0.0.1:0/cb"],
+               :exact_allow_loopback_port
+             )
+    end
+
     test "an empty registered set still matches nothing" do
       refute RedirectURI.registered?("http://127.0.0.1:51823/cb", [], :exact_allow_loopback_port)
     end


### PR DESCRIPTION
Adds the authorization-server half of [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) (OAuth 2.0 for Native Apps, BCP 212) §7.3: loopback interface redirection, as an **opt-in** redirect-URI matching mode.

## Why

A native app that cannot use a private-use URI scheme binds an ephemeral port on the loopback interface at runtime, so the port is unknown at registration time. §7.3 requires the authorization server to permit a variable port for loopback redirect URIs while comparing the rest of the URI exactly.

## What

New `Attesto.RedirectURI` owns both comparison modes, selected by a new `:redirect_uri_matching` option on `Attesto.AuthorizationRequest.validate/2`:

- `:exact` (default) — the RFC 6749 §3.1.2.3 simple string comparison, unchanged.
- `:exact_allow_loopback_port` — exact first, then the §7.3 exception.

The exception is deliberately narrow. It applies only when both URIs begin with the byte-exact scheme `http://`, have an authority of exactly `127.0.0.1` or `[::1]` with an optional port, and carry no fragment. Scheme, host literal, path, and query still compare exactly; only the port is ignored. `https`, private-use schemes, remote hosts, userinfo, alternative spellings of the loopback address, and case variants of the scheme all stay exact-match.

`localhost` is excluded from the exception — it is a *name* whose resolution the server cannot reason about (§8.3). A deliberately registered `localhost` URI is still reachable by exact match; it just gets no port flexibility.

The two sides are asymmetric in one respect: a port on the **request** URI must be decimal 1–65535 or absent, since it names an endpoint a browser is about to be redirected to. The **registered** URI's port is discarded, so any port stands there — including the conventional `:0` placeholder.

## Compatibility

Default-off. Without the option, redirect matching is byte-identical to previous releases. An unmatched redirect URI is still `{:direct, :redirect_uri_not_registered}` and is never used as a redirect target under any mode. Redemption-time comparison in `Attesto.AuthorizationCode` is unaffected — the code binds the URI the client actually presented, ephemeral port included, and still matches exactly.

Enabling the exception widens a check the OpenID Connect and FAPI profiles assume is exact, so it is documented as incompatible with certifying against them.

## Verification

- 1584 tests, credo --strict, dialyzer, format all clean.
- Two independent adversarial security reviews (GPT/Codex at xhigh, and Claude Fable). Neither found an open redirect; Fable verified by running the toolchain against the URI-parsing differential classes (backslashes, tabs, percent-encoding, IDN, NUL, zone ids, `[::ffff:127.0.0.1]`, trailing dots, userinfo splicing). Findings on port range and `localhost` handling were applied or answered.
- OIDF conformance run against a live OP built from this branch: FAPI2 Security Profile 56/56 with zero failures, Basic OP zero failures.