### PR TITLE
Refuse redirect URIs whose origin depends on the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-07-28
+
+### Security
+
+- Reject a Client ID Metadata Document whose `redirect_uris` contain a URI that
+  RFC 3986 and the WHATWG URL Standard read differently
+  (`{:error, :invalid_redirect_uris}`).
+
+  A CIMD document is fetched from a URL the client itself chose, so its
+  `redirect_uris` are supplied by the client in a way a host-registered set is
+  not. Elixir's `URI` follows RFC 3986 while the browser that receives the
+  `Location` follows WHATWG, and the two disagree about some authorities: in
+  `https://evil.example\@client.example/cb`, RFC 3986 reads `evil.example\` as
+  userinfo and `client.example` as the host, while WHATWG treats the backslash
+  as a path separator and navigates to `evil.example`.
+
+  Any check phrased in terms of a *host* or an *origin* — the CIMD draft's
+  same-origin tightening, a deployment's origin allow-list — is decided with the
+  first parser and enforced by the second, so such a URI could pass the check
+  and still send the authorization response off-origin. Refusing the document
+  keeps the URI out of the registered set those checks ever run against.
+
+  Byte-exact matching (RFC 6749 §3.1.2.3) was never affected: it compares
+  strings, not origins. The RFC 8252 §7.3 loopback exception was never affected
+  either, because it anchors on the whole authority rather than the parsed host
+  — `http://evil.example\@127.0.0.1/cb` was already refused.
+
+### Added
+
+- `Attesto.RedirectURI.unambiguous?/1`, the predicate behind the above: whether
+  every URL parser agrees which origin a URI names. It refuses backslashes,
+  userinfo, and C0 controls/whitespace anywhere in the URI. Exposed so a host
+  applying its own origin-level policy to a redirect URI can gate on the same
+  rule.
+
+  This governs what may be *registered*; it is not a matching mode and does not
+  change what `registered?/3` accepts.
+
+### Changed
+
+- The WHATWG parity suite now pins a second invariant alongside the loopback
+  one: for every URI `unambiguous?/1` admits, the host RFC 3986 reads and the
+  host WHATWG reads are the same string.
+
 ## [1.4.1] - 2026-07-28
 
 ### Documentation

--- a/lib/attesto/client_id_metadata.ex
+++ b/lib/attesto/client_id_metadata.ex
@@ -268,10 +268,20 @@ defmodule Attesto.ClientIdMetadata do
   # RFC 9700: the AS MUST require registered redirect URIs and exact-match the
   # request's, so a CIMD document MUST carry a non-empty `redirect_uris` array
   # of strings. An absent, empty, or non-string-list value is rejected.
+  #
+  # Each URI must also be one every URL parser reads the same way
+  # (`Attesto.RedirectURI.unambiguous?/1`). A CIMD document is fetched from a
+  # URL the client chose, so its `redirect_uris` are attacker-supplied in a way
+  # a host-registered set is not, and any origin-level policy applied to them
+  # later - the draft's same-origin tightening, a deployment's allow-list - is
+  # decided with an RFC 3986 parser but enforced by a browser using WHATWG
+  # rules. Rejecting the ambiguity here means no such URI is ever in the set
+  # those checks run against, which is the one place the two parsers cannot
+  # already have diverged.
   defp validate_redirect_uris(doc) do
     case Map.get(doc, "redirect_uris") do
       [_ | _] = uris ->
-        if Enum.all?(uris, &is_binary/1) do
+        if Enum.all?(uris, &Attesto.RedirectURI.unambiguous?/1) do
           {:ok, uris}
         else
           {:error, :invalid_redirect_uris}

--- a/lib/attesto/redirect_uri.ex
+++ b/lib/attesto/redirect_uri.ex
@@ -89,6 +89,22 @@ defmodule Attesto.RedirectURI do
   trusted redirect target, and the caller MUST report the failure directly to
   the user agent rather than redirecting to the supplied URI (OIDC Core
   §3.1.2.6) - otherwise the endpoint is an open redirect.
+
+  ## Parser agreement
+
+  Matching is only as sound as the agreement between the parser that *decides*
+  and the parser that *navigates*. Elixir's `URI` follows RFC 3986; the browser
+  that receives the `Location` follows the WHATWG URL Standard, and the two
+  disagree about some authorities. In `https://evil.example\\@client.example/cb`,
+  RFC 3986 reads `evil.example\\` as userinfo and `client.example` as the host,
+  while WHATWG treats the backslash as a path separator and navigates to
+  `evil.example`.
+
+  Byte-exact matching is immune - it compares strings, never origins - and the
+  §7.3 loopback exception is immune because it anchors on the whole authority
+  rather than the parsed host. Any check phrased in terms of a *host* or an
+  *origin* is not, so `unambiguous?/1` exists to keep such a URI out of a
+  registered set in the first place.
   """
 
   @typedoc "The redirect-URI matching mode (see the moduledoc)."
@@ -118,6 +134,12 @@ defmodule Attesto.RedirectURI do
   @min_port 1
   @max_port 65_535
 
+  # The bytes whose treatment differs between RFC 3986 and the WHATWG URL
+  # Standard (see `unambiguous?/1`): C0 controls, space, and the backslash.
+  # Matched against the raw string rather than a parsed component, since the
+  # disagreement is precisely about where the components begin and end.
+  @ambiguous_bytes ~r/[\x00-\x20\x7f\\]/
+
   @doc """
   The supported matching modes. Exposed so a caller can validate host
   configuration against the same list this module enforces.
@@ -140,6 +162,44 @@ defmodule Attesto.RedirectURI do
   def matching!(other) do
     raise ArgumentError,
           "invalid redirect_uri matching mode #{inspect(other)}; expected one of #{inspect(@matching_modes)}"
+  end
+
+  @doc """
+  Whether every URL parser agrees which origin `uri` names (see "Parser
+  agreement" in the moduledoc).
+
+  Answers `false` for a URI carrying anything that makes RFC 3986 and the WHATWG
+  URL Standard read a different authority out of the same bytes:
+
+    * a **backslash** anywhere. WHATWG maps `\\` to `/` in a special scheme, so
+      it can terminate an authority that RFC 3986 reads as continuing.
+    * **userinfo**. `https://a@b/` is unambiguous today, but userinfo is the
+      component every authority-confusion trick is built out of, and a redirect
+      URI has no legitimate use for credentials (RFC 6749 §3.1.2 wants a plain
+      absolute URI). Refusing it removes the whole class rather than the one
+      spelling known to differ.
+    * a **C0 control, space, tab, CR, or LF**. WHATWG strips tab/CR/LF before
+      parsing and percent-encodes the rest; RFC 3986 does neither.
+
+  A URI that does not parse at all is likewise `false` - it is not a target the
+  server can reason about.
+
+  This is a check on what may be *registered*, not a matching mode. It says
+  nothing about whether a URI is a good redirect target, only that the answer
+  will not depend on which parser is asked.
+  """
+  @spec unambiguous?(term()) :: boolean()
+  def unambiguous?(uri) when is_binary(uri) do
+    not Regex.match?(@ambiguous_bytes, uri) and no_userinfo?(uri)
+  end
+
+  def unambiguous?(_uri), do: false
+
+  defp no_userinfo?(uri) do
+    case URI.new(uri) do
+      {:ok, %URI{userinfo: nil}} -> true
+      _ -> false
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.4.1"
+  @version "1.5.0"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 

--- a/test/attesto/client_id_metadata_test.exs
+++ b/test/attesto/client_id_metadata_test.exs
@@ -211,6 +211,39 @@ defmodule Attesto.ClientIdMetadataTest do
       assert {:error, :invalid_redirect_uris} =
                ClientIdMetadata.validate_document(client_id, doc)
     end
+
+    # A CIMD document is fetched from a URL the client chose, so its
+    # `redirect_uris` are attacker-supplied. One whose authority two URL parsers
+    # read differently would let the same-origin tightening approve a host the
+    # browser never navigates to, so it never enters the registered set.
+    test "rejects a redirect_uri whose host depends on which parser reads it" do
+      client_id = "https://app.example/meta"
+
+      for uri <- [
+            "https://evil.example\\@app.example/cb",
+            "https://evil.example@app.example/cb",
+            "https://evil.example\t@app.example/cb",
+            "https://app.example/c b"
+          ] do
+        doc = %{"client_id" => client_id, "redirect_uris" => [uri]}
+
+        assert {:error, :invalid_redirect_uris} =
+                 ClientIdMetadata.validate_document(client_id, doc),
+               "expected #{inspect(uri)} to be rejected"
+      end
+    end
+
+    test "rejects the whole document when only one redirect_uri is ambiguous" do
+      client_id = "https://app.example/meta"
+
+      doc = %{
+        "client_id" => client_id,
+        "redirect_uris" => ["https://app.example/cb", "https://evil.example\\@app.example/cb"]
+      }
+
+      assert {:error, :invalid_redirect_uris} =
+               ClientIdMetadata.validate_document(client_id, doc)
+    end
   end
 
   describe "validate_document/2 normalization (RFC 7591 §2)" do

--- a/test/attesto/redirect_uri_test.exs
+++ b/test/attesto/redirect_uri_test.exs
@@ -280,4 +280,80 @@ defmodule Attesto.RedirectURITest do
       refute RedirectURI.registered?("https://evil.example/cb", ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
     end
   end
+
+  describe "unambiguous?/1" do
+    test "admits ordinary redirect URIs" do
+      for uri <- [
+            "https://client.example/cb",
+            "https://client.example:8443/cb?a=1",
+            "http://127.0.0.1:51823/cb",
+            "http://[::1]/cb",
+            "com.example.app:/oauth2redirect",
+            "com.example.app://callback"
+          ] do
+        assert RedirectURI.unambiguous?(uri), "expected #{inspect(uri)} to be admitted"
+      end
+    end
+
+    # The finding this predicate exists for: RFC 3986 reads `evil.example\` as
+    # userinfo and `client.example` as the host, so an origin check phrased in
+    # terms of `URI.parse/1` approves it - while a browser terminates the
+    # authority at the backslash and navigates to `evil.example`.
+    test "refuses a backslash, whichever host each parser ends up reading" do
+      for uri <- [
+            "https://evil.example\\@client.example/cb",
+            "https://client.example\\@evil.example/cb",
+            "https://client.example/cb\\@evil.example",
+            "http://127.0.0.1\\@evil.example/cb"
+          ] do
+        refute RedirectURI.unambiguous?(uri), "expected #{inspect(uri)} to be refused"
+      end
+    end
+
+    # Userinfo has no legitimate place in a redirect URI, and every authority
+    # confusion trick is built from it. Refused as a class rather than only in
+    # the spellings currently known to differ between parsers.
+    test "refuses userinfo even where the parsers agree" do
+      refute RedirectURI.unambiguous?("https://evil.example@client.example/cb")
+      refute RedirectURI.unambiguous?("https://user:pw@client.example/cb")
+      refute RedirectURI.unambiguous?("https://@client.example/cb")
+    end
+
+    test "an `@` in the path is not userinfo and stays admissible" do
+      assert RedirectURI.unambiguous?("https://client.example/@handle/cb")
+      assert RedirectURI.unambiguous?("https://client.example/cb?to=a@b")
+    end
+
+    # WHATWG strips tab/CR/LF before parsing and percent-encodes other control
+    # characters; RFC 3986 does neither, so the two can disagree about where
+    # the authority ends.
+    test "refuses control characters and whitespace" do
+      for uri <- [
+            "https://evil.example\t@client.example/cb",
+            "https://evil.example\n@client.example/cb",
+            "https://evil.example\r@client.example/cb",
+            "https://client.example/c b",
+            "https://client.example/cb\0",
+            "https://client.example/cb\x7f"
+          ] do
+        refute RedirectURI.unambiguous?(uri), "expected #{inspect(uri)} to be refused"
+      end
+    end
+
+    test "refuses anything that is not a parseable binary" do
+      refute RedirectURI.unambiguous?("https://client.example/cb|pipe")
+      refute RedirectURI.unambiguous?(nil)
+      refute RedirectURI.unambiguous?(:uri)
+      refute RedirectURI.unambiguous?(["https://client.example/cb"])
+    end
+
+    # The predicate governs what may be REGISTERED; it is not a matching mode
+    # and must not quietly change what `registered?/3` accepts.
+    test "does not affect matching, which stays byte-exact" do
+      ambiguous = "https://evil.example\\@client.example/cb"
+
+      assert RedirectURI.registered?(ambiguous, [ambiguous], :exact)
+      refute RedirectURI.unambiguous?(ambiguous)
+    end
+  end
 end

--- a/test/parity/redirect_uri_whatwg_parity_test.exs
+++ b/test/parity/redirect_uri_whatwg_parity_test.exs
@@ -103,6 +103,9 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
 
   defp whatwg(uri), do: NodeBridge.call!("attesto_compat", :whatwgUrl, [uri])
 
+  defp unbracket(host) when is_binary(host), do: String.trim_leading(host, "[") |> String.trim_trailing("]")
+  defp unbracket(host), do: host
+
   defp accepted?(uri, matching), do: RedirectURI.registered?(uri, @registered, matching)
 
   describe "the accept-set never escapes loopback (RFC 8252 §7.3)" do
@@ -201,6 +204,87 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
         assert whatwg(uri)["ok"] == false
         refute accepted?(uri, :exact_allow_loopback_port)
       end
+    end
+  end
+
+  describe "unambiguous?/1 admits only URIs both parsers read alike" do
+    # The loopback rule is safe because it compares a whole AUTHORITY. A check
+    # phrased in terms of a HOST - the CIMD same-origin tightening, a
+    # deployment's origin allow-list - has no such protection: it asks one
+    # parser where a URI points and a browser answers differently.
+    #
+    #   THE INVARIANT - for every URI `unambiguous?/1` accepts, the host RFC
+    #   3986 reads and the host WHATWG reads are the same string.
+    #
+    # This is what makes it sound to decide an origin question with `URI.parse/1`
+    # once the predicate has passed.
+    @origin_corpus [
+      # Ordinary registrable redirect URIs, both families and both schemes.
+      "https://client.example/cb",
+      "https://client.example:8443/cb",
+      "https://sub.client.example/cb?a=1",
+      "http://127.0.0.1:51823/cb",
+      "http://[::1]/cb",
+      # A private-use scheme (RFC 8252 §7.1) has no authority to disagree over.
+      "com.example.app:/oauth2redirect",
+      # An `@` in the PATH is not userinfo and must stay admissible.
+      "https://client.example/@handle/cb",
+      # The differential itself, and its neighbours.
+      "https://evil.example\\@client.example/cb",
+      "https://evil.example\\\\@client.example/cb",
+      "https://client.example\\@evil.example/cb",
+      "https://evil.example@client.example/cb",
+      "https://client.example@evil.example/cb",
+      "https://evil.example\t@client.example/cb",
+      "https://evil.example\n@client.example/cb",
+      "https://evil.example\r@client.example/cb",
+      "https://client.example/cb\\@evil.example",
+      "https://client.example /cb",
+      "https://client.example /cb"
+    ]
+
+    test "every admitted URI names the same host under both parsers" do
+      offenders =
+        for uri <- @origin_corpus, RedirectURI.unambiguous?(uri) do
+          parsed = whatwg(uri)
+          rfc = URI.parse(uri).host
+
+          cond do
+            parsed["ok"] != true ->
+              {uri, "WHATWG refuses to parse it"}
+
+            # A scheme with no authority (private-use) has no host on either
+            # side; nothing to disagree about.
+            is_nil(rfc) and parsed["hostname"] in [nil, ""] ->
+              nil
+
+            # `URI.parse/1` returns an IPv6 literal unbracketed and `URL.hostname`
+            # returns it bracketed. That is a spelling difference in how the two
+            # report the same address, not a disagreement about which host is
+            # named, so compare with the brackets removed.
+            unbracket(parsed["hostname"]) != unbracket(rfc) ->
+              {uri, "RFC 3986 reads host #{inspect(rfc)}, WHATWG reads #{inspect(parsed["hostname"])}"}
+
+            true ->
+              nil
+          end
+        end
+        |> Enum.reject(&is_nil/1)
+
+      assert offenders == [],
+             "URIs admitted as unambiguous whose host depends on the parser:\n" <>
+               Enum.map_join(offenders, "\n", fn {uri, why} -> "  #{inspect(uri)} - #{why}" end)
+    end
+
+    test "the corpus actually exercises the predicate (guards against a vacuous pass)" do
+      admitted = Enum.filter(@origin_corpus, &RedirectURI.unambiguous?/1)
+      refused = Enum.reject(@origin_corpus, &RedirectURI.unambiguous?/1)
+
+      assert "https://client.example/cb" in admitted
+      assert "com.example.app:/oauth2redirect" in admitted
+      assert "https://client.example/@handle/cb" in admitted, "an `@` in the path is not userinfo"
+      assert "https://evil.example\\@client.example/cb" in refused
+      assert length(refused) >= 8
     end
   end
 end


### PR DESCRIPTION
Elixir's `URI` follows RFC 3986; the browser that receives the `Location` follows the WHATWG URL Standard, and the two disagree about some authorities:

```
https://evil.example\@client.example/cb
  RFC 3986 (URI.parse):  host = client.example
  WHATWG   (browser):    host = evil.example
```

Byte-exact matching (RFC 6749 §3.1.2.3) is immune — it compares strings, never origins. The RFC 8252 §7.3 loopback exception is immune because it anchors on the whole authority rather than the parsed host, so `http://evil.example\@127.0.0.1/cb` was already refused.

Any check phrased in terms of a **host** or an **origin** is not immune. A CIMD document supplies its own `redirect_uris` from a URL the client chose, so such a URI could pass an origin-level check — the draft's same-origin tightening, a deployment's allow-list — and still send the authorization response somewhere else.

## Changes

- Add `Attesto.RedirectURI.unambiguous?/1`: whether every URL parser agrees which origin a URI names. Refuses backslashes, userinfo, and C0 controls/whitespace anywhere in the URI.
- Reject a CIMD document declaring a redirect URI it refuses (`{:error, :invalid_redirect_uris}`), keeping such a URI out of the registered set those checks run against.

The predicate governs what may be **registered**. It is not a matching mode; `registered?/3` is unchanged.

## Tests

The WHATWG parity suite gains the corresponding invariant: for every URI admitted as unambiguous, the host RFC 3986 reads and the host WHATWG reads are the same string — driven through Node as an independent parser implementation, with a vacuous-pass guard.

Full suite 1601 passed, credo clean, dialyzer clean.