### PR TITLE
Replay-claim ordering, security telemetry, and four rounds of adversarial review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,14 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   mismatch, so its duration cannot separate "wrong length" from "right length,
   wrong bytes". Both operands are hashed to 32 bytes and those are compared.
 
-  No call site inside this library was leaking: `Attesto.PKCE.verify/3` gates on
-  `Attesto.Thumbprint.valid?/1`, which requires an exact byte size. The function
-  is public and its name is an unconditional promise, so it should hold for a
-  host comparing a variable-length value of its own.
+  `Attesto.PKCE.verify/3` was never exposed - it gates on
+  `Attesto.Thumbprint.valid?/1`, which requires an exact byte size - but
+  `Attesto.DPoP`'s `ath` comparison takes an arbitrary-length value straight
+  from the presented proof, so it was, and it is the caller this most benefits.
+
+  Note what the change does and does not buy: the comparison no longer reveals
+  HOW the operands differ, but hashing reads every byte, so its duration still
+  depends on their total size.
 
 ### Added
 
@@ -46,8 +50,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
   Previously these returned an atom and nothing else, so a host that wanted to
   alert had to wrap every call site. Metadata carries correlation handles
-  (`family_id`, `client_id`, `subject`, `jti`, `binding`, `reason`) and never a
-  token, code, secret, assertion, or hash of one. Ordinary failures — expired,
+  (`family_id`, `client_id`, `subject`, `jti`, `binding`, `reason`), none of
+  them derived by Attesto from a token, code, secret, or assertion - though
+  `jti` is chosen by the client and the rest are the host's own identifiers, so
+  a handler should treat metadata as untrusted input. Ordinary failures — expired,
   unknown client, wrong scope — are deliberately not events. Event names and
   metadata keys are public API; see the module docs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   unauthenticated.
 
 - `Attesto.SecureCompare.equal?/2` no longer short-circuits on a length
-  mismatch, so its duration cannot separate "wrong length" from "right length,
-  wrong bytes". Both operands are hashed to 32 bytes and those are compared.
+  mismatch. There is no early return keyed on length or equality, so the
+  comparison does not separate "wrong length" from "right length, wrong bytes".
+  Both operands are hashed to 32 bytes and those are compared.
 
   `Attesto.PKCE.verify/3` was never exposed - it gates on
   `Attesto.Thumbprint.valid?/1`, which requires an exact byte size - but
@@ -50,10 +51,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
   Previously these returned an atom and nothing else, so a host that wanted to
   alert had to wrap every call site. Metadata carries correlation handles
-  (`family_id`, `client_id`, `subject`, `jti`, `binding`, `reason`), none of
-  them derived by Attesto from a token, code, secret, or assertion - though
-  `jti` is chosen by the client and the rest are the host's own identifiers, so
-  a handler should treat metadata as untrusted input. Ordinary failures — expired,
+  (`family_id`, `client_id`, `subject`, `jti`, `binding`, `reason`). No
+  credential or digest of one is ever copied into an event, but some handles are
+  read out of credentials - `jti` from the proof, `client_id` from the token -
+  and `jti` is the client's to choose, so a handler should treat metadata as
+  untrusted input. The events are indicators to correlate, not proof of theft. Ordinary failures — expired,
   unknown client, wrong scope — are deliberately not events. Event names and
   metadata keys are public API; see the module docs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,67 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Claim a DPoP proof's `jti` only after the access token has verified.
+  `Attesto.Plug.Authenticate` ran `:replay_check` during proof validation, two
+  steps before `verify_token`. That callback is check-AND-record — the default
+  claims the identifier with `:ets.insert_new/2` in the same step that tests it
+  — so an unauthenticated caller wrote a row on every request. A DPoP proof is
+  signed by a key the caller generated, so anyone can mint a valid one, pair it
+  with any string in the `Authorization` header, and grow an unbounded ETS table
+  for the cost of a signature.
+
+  The guarantee is unchanged: the claim still happens before the request is
+  served, it is still the same atomic check-and-record, and a replayed `jti` on
+  an otherwise-valid request is still refused (RFC 9449 §11.1). The
+  authorization-server path needed no change — `%Request{}` carries the
+  already-authenticated client, so its claim was never reachable
+  unauthenticated.
+
+- `Attesto.SecureCompare.equal?/2` no longer short-circuits on a length
+  mismatch, so its duration cannot separate "wrong length" from "right length,
+  wrong bytes". Both operands are hashed to 32 bytes and those are compared.
+
+  No call site inside this library was leaking: `Attesto.PKCE.verify/3` gates on
+  `Attesto.Thumbprint.valid?/1`, which requires an exact byte size. The function
+  is public and its name is an unconditional promise, so it should hold for a
+  host comparing a variable-length value of its own.
+
+### Added
+
+- `Attesto.Telemetry` — `:telemetry` events for the refusals that mean someone
+  holds a credential they should not:
+
+  | Event | Fires when |
+  |---|---|
+  | `[:attesto, :refresh_token, :reuse_detected]` | a rotated token is presented again; the family has been revoked |
+  | `[:attesto, :dpop, :replay_detected]` | a proof carries an already-recorded `jti` |
+  | `[:attesto, :token, :sender_constraint_mismatch]` | a sender-bound token is presented with the wrong proof of possession |
+
+  Previously these returned an atom and nothing else, so a host that wanted to
+  alert had to wrap every call site. Metadata carries correlation handles
+  (`family_id`, `client_id`, `subject`, `jti`, `binding`, `reason`) and never a
+  token, code, secret, assertion, or hash of one. Ordinary failures — expired,
+  unknown client, wrong scope — are deliberately not events. Event names and
+  metadata keys are public API; see the module docs.
+
+  Adds `:telemetry` as a dependency.
+
+- `Attesto.DPoP.verify_proof/2` now reports the `replay_ttl` it derived, so a
+  caller claiming the `jti` itself uses that verification's own acceptance
+  window rather than re-deriving the formula.
+
+### Documentation
+
+- `Attesto.DPoP.ReplayCache` now names `AttestoPhoenix.Store.EctoReplayCheck` as
+  the shared-store implementation to use on a multi-node deployment. It
+  previously described one in the abstract ("e.g. a Postgres-backed cache"),
+  which read as an instruction to go and build something the family already
+  ships.
+
 ## [1.5.0] - 2026-07-28
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.0] - 2026-08-01
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,21 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
   The guarantee is unchanged: the claim still happens before the request is
   served, it is still the same atomic check-and-record, and a replayed `jti` on
-  an otherwise-valid request is still refused (RFC 9449 §11.1). The
-  authorization-server path needed no change — `%Request{}` carries the
-  already-authenticated client, so its claim was never reachable
-  unauthenticated.
+  an otherwise-valid request is still refused (RFC 9449 §11.1).
+
+  The authorization-server path needed the same fix, in `attesto_phoenix` — an
+  earlier draft of this entry claimed it did not, on the grounds that
+  `%Request{}` carries an authenticated client. That is false for a **public
+  client** (RFC 6749 §2.1), which presents a `client_id` and no credential, so
+  the same unauthenticated write was reachable at the token endpoint. See that
+  package's changelog.
 
 - `Attesto.SecureCompare.equal?/2` no longer short-circuits on a length
-  mismatch. There is no early return keyed on length or equality, so the
-  comparison does not separate "wrong length" from "right length, wrong bytes".
-  Both operands are hashed to 32 bytes and those are compared.
+  mismatch. Both operands are hashed to 32 bytes and those digests are
+  compared, so the comparison no longer separates "wrong length" from "right
+  length, wrong bytes" — the distinction an attacker probes with. A matching
+  pair does one extra byte comparison to rule out a digest collision; that
+  branch separates right from wrong, which the answer already reveals.
 
   `Attesto.PKCE.verify/3` was never exposed - it gates on
   `Attesto.Thumbprint.valid?/1`, which requires an exact byte size - but

--- a/README.md
+++ b/README.md
@@ -358,16 +358,28 @@ fixed plug.
 ## Security telemetry
 
 Most refusals are routine — an expired token, an unknown client, a scope
-that was not granted. Three are not. Each of these means someone is
-holding a credential they should not, and each is emitted as a
-[`:telemetry`](https://hexdocs.pm/telemetry) event so it can reach a pager
-or a SIEM without wrapping every call site:
+that was not granted. Three are the shape a stolen credential makes, and
+each is emitted as a [`:telemetry`](https://hexdocs.pm/telemetry) event so
+it can reach a pager or a SIEM without wrapping every call site:
 
 | Event | Fires when |
 |---|---|
 | `[:attesto, :refresh_token, :reuse_detected]` | a rotated refresh token is presented again — **the family has already been revoked**, so this is the only notice that the session ended for a reason |
 | `[:attesto, :dpop, :replay_detected]` | a DPoP proof carries a `jti` the replay store already recorded |
 | `[:attesto, :token, :sender_constraint_mismatch]` | a DPoP- or mTLS-bound token is presented with the wrong proof of possession |
+
+**Indicators, not verdicts.** None of them proves theft. A client can
+present its own bound token under a second key as often as it likes, and a
+key rotation or a stale cached key produces the same mismatch innocently —
+so rate-limit and correlate before paging. `reuse_detected` is the one
+worth escalating fastest, because reaching it has already revoked the
+family. A rotation that finds its family revoked underneath it returns
+`:grant_revoked` and emits **nothing**: an ordinary logout can cause it,
+and the library cannot tell the two apart.
+
+**Handlers run synchronously.** `:telemetry` invokes them on the calling
+process with no timeout, so a handler that blocks blocks the refusal that
+produced the event. Hand work to a queue and return.
 
 ```elixir
 :telemetry.attach_many(

--- a/README.md
+++ b/README.md
@@ -379,16 +379,17 @@ or a SIEM without wrapping every call site:
 ```
 
 Metadata carries correlation handles — `family_id`, `client_id`,
-`subject`, `jti`, `binding`, `reason`. Attesto never derives them from a
-credential: no token, code, secret, or assertion is put into an event, in
-plaintext or hashed.
+`subject`, `jti`, `binding`, `reason`. No token, code, secret, or assertion
+is ever copied into an event, in plaintext or hashed, and nothing emitted
+can be presented to obtain anything.
 
-That is not the same as the bytes being harmless. `jti` is chosen by the
-client and emitted unchanged, and `client_id` / `subject` / `family_id` are
-the host's own identifiers, so a handler is writing values it did not
-choose — treat metadata as untrusted input wherever it sends it.
-`Attesto.Telemetry` documents this in full; event names and metadata keys
-are public API.
+Some of those handles are read out of credentials, though — `jti` from the
+DPoP proof, `client_id` from the presented token — and carry whatever their
+author put there. `jti` in particular is the client's to choose. Treat
+metadata as untrusted input wherever the handler sends it, and treat the
+events as indicators to correlate rather than proof of theft;
+`Attesto.Telemetry` covers both. Event names and metadata keys are public
+API.
 
 Routine failures are deliberately **not** events. Emitting them would bury
 the three above in traffic that is simply what a healthy authorization

--- a/README.md
+++ b/README.md
@@ -379,10 +379,16 @@ or a SIEM without wrapping every call site:
 ```
 
 Metadata carries correlation handles — `family_id`, `client_id`,
-`subject`, `jti`, `binding`, `reason` — and never a token, code, secret,
-assertion, or a hash of one, so a handler that writes metadata straight to
-a log cannot thereby write a credential to disk. Event names and metadata
-keys are public API; see `Attesto.Telemetry`.
+`subject`, `jti`, `binding`, `reason`. Attesto never derives them from a
+credential: no token, code, secret, or assertion is put into an event, in
+plaintext or hashed.
+
+That is not the same as the bytes being harmless. `jti` is chosen by the
+client and emitted unchanged, and `client_id` / `subject` / `family_id` are
+the host's own identifiers, so a handler is writing values it did not
+choose — treat metadata as untrusted input wherever it sends it.
+`Attesto.Telemetry` documents this in full; event names and metadata keys
+are public API.
 
 Routine failures are deliberately **not** events. Emitting them would bury
 the three above in traffic that is simply what a healthy authorization

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ token, DPoP, and scope checks as Plug modules and adds the MCP-facing
 - [What you supply / what's in the box](#what-you-supply--whats-in-the-box)
 - [RFC coverage](#rfc-coverage)
 - [Plug integration (optional)](#plug-integration-optional)
+- [Security telemetry](#security-telemetry)
 - [Cluster safety](#cluster-safety)
 - [Status](#status)
 - [Development](#development)
@@ -123,7 +124,7 @@ token, DPoP, and scope checks as Plug modules and adds the MCP-facing
 ```elixir
 def deps do
   [
-    {:attesto, "~> 1.4"}
+    {:attesto, "~> 1.5"}
   ]
 end
 ```
@@ -354,6 +355,39 @@ add it only if you use this layer. The token-endpoint grant logic stays
 yours - client auth, policy, and store wiring are too host-specific for a
 fixed plug.
 
+## Security telemetry
+
+Most refusals are routine — an expired token, an unknown client, a scope
+that was not granted. Three are not. Each of these means someone is
+holding a credential they should not, and each is emitted as a
+[`:telemetry`](https://hexdocs.pm/telemetry) event so it can reach a pager
+or a SIEM without wrapping every call site:
+
+| Event | Fires when |
+|---|---|
+| `[:attesto, :refresh_token, :reuse_detected]` | a rotated refresh token is presented again — **the family has already been revoked**, so this is the only notice that the session ended for a reason |
+| `[:attesto, :dpop, :replay_detected]` | a DPoP proof carries a `jti` the replay store already recorded |
+| `[:attesto, :token, :sender_constraint_mismatch]` | a DPoP- or mTLS-bound token is presented with the wrong proof of possession |
+
+```elixir
+:telemetry.attach_many(
+  "attesto-security",
+  Attesto.Telemetry.events(),
+  &MyApp.Security.handle_event/4,
+  nil
+)
+```
+
+Metadata carries correlation handles — `family_id`, `client_id`,
+`subject`, `jti`, `binding`, `reason` — and never a token, code, secret,
+assertion, or a hash of one, so a handler that writes metadata straight to
+a log cannot thereby write a credential to disk. Event names and metadata
+keys are public API; see `Attesto.Telemetry`.
+
+Routine failures are deliberately **not** events. Emitting them would bury
+the three above in traffic that is simply what a healthy authorization
+server looks like.
+
 ## Cluster safety
 
 The engine is pure and stateless, so it is **cluster-safe by
@@ -362,7 +396,12 @@ node. All *state* (authorization codes, refresh-token families, seen DPoP
 `jti` values, DPoP nonces) lives behind storage behaviours whose contracts
 mandate the atomic primitives (atomic `take`, atomic compare-and-set
 `consume`, sticky family revocation). Implement those behaviours over a
-shared store (Postgres, Redis) and the whole system is cluster-safe.
+shared store (Postgres, Redis) and the whole system is cluster-safe — or
+take [`attesto_phoenix`](https://hex.pm/packages/attesto_phoenix), which
+ships Ecto implementations of all of them (including
+`AttestoPhoenix.Store.EctoReplayCheck`, whose unique constraint on `jti`
+makes the DPoP record-and-check atomic across nodes) with migrations and
+an expiry sweeper.
 
 The bundled ETS reference stores are deliberately **single-node** - a
 captured credential would otherwise be replayable once per node. Rather
@@ -374,7 +413,7 @@ constraint.
 
 ## Status
 
-A stable `1.x` release: the public API follows [semantic versioning](https://semver.org/) — minor and patch releases are backward-compatible and breaking changes wait for a new major version (read the CHANGELOG before upgrading). Implemented and tested: token issue/verify, DPoP, mTLS certificate-bound tokens, scope, keystore, PKCE validation, JWKS publication, OIDC discovery, the authorization-code grant (single-use, optionally DPoP-bound), refresh-token rotation with reuse detection, token revocation (RFC 7009, refresh-token family), Pushed Authorization Request primitives (RFC 9126), Resource Indicators (RFC 8707), signed request-object policy (JAR) and JARM response signing, token introspection and signed introspection response JWTs, Step-Up Authentication challenges (RFC 9470), the JWT-assertion (`jwt-bearer`) grant, the Device Authorization Grant (RFC 8628), Client-Initiated Backchannel Authentication (CIBA; poll/ping, signed requests per FAPI-CIBA), the RP-Initiated / Back-Channel / Front-Channel Logout and Session Management primitives, RFC 9728 protected-resource metadata, and Client ID Metadata Document (CIMD) verification. The stateful grants run against the `Attesto.CodeStore` / `Attesto.RefreshStore` behaviours, with ETS reference implementations included; a production host implements those over its own database (the atomic-`take` and atomic-`consume` contracts are documented). Cross-language parity tests check Attesto-issued artifacts against a reference implementation in another language. Pin to `~> 1.4`.
+A stable `1.x` release: the public API follows [semantic versioning](https://semver.org/) — minor and patch releases are backward-compatible and breaking changes wait for a new major version (read the CHANGELOG before upgrading). Implemented and tested: token issue/verify, DPoP, mTLS certificate-bound tokens, scope, keystore, PKCE validation, JWKS publication, OIDC discovery, the authorization-code grant (single-use, optionally DPoP-bound), refresh-token rotation with reuse detection, token revocation (RFC 7009, refresh-token family), Pushed Authorization Request primitives (RFC 9126), Resource Indicators (RFC 8707), signed request-object policy (JAR) and JARM response signing, token introspection and signed introspection response JWTs, Step-Up Authentication challenges (RFC 9470), the JWT-assertion (`jwt-bearer`) grant, the Device Authorization Grant (RFC 8628), Client-Initiated Backchannel Authentication (CIBA; poll/ping, signed requests per FAPI-CIBA), the RP-Initiated / Back-Channel / Front-Channel Logout and Session Management primitives, RFC 9728 protected-resource metadata, Client ID Metadata Document (CIMD) verification, and `:telemetry` events for security-relevant refusals. The stateful grants run against the `Attesto.CodeStore` / `Attesto.RefreshStore` behaviours, with ETS reference implementations included; a production host either takes the Ecto implementations from `attesto_phoenix` or writes its own (the atomic-`take` and atomic-`consume` contracts are documented). Cross-language parity tests check Attesto-issued artifacts against a reference implementation in another language. Pin to `~> 1.5`.
 
 ## Development
 

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -550,6 +550,10 @@ defmodule Attesto.DPoP do
             :ok
 
           {:error, :replay} ->
+            # RFC 9449 §11.1: this proof was captured and replayed, or a
+            # client is reusing identifiers it must not. See
+            # `Attesto.Telemetry`.
+            Attesto.Telemetry.dpop_replay_detected(jti)
             {:error, :replay}
 
           other ->

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -107,7 +107,8 @@ defmodule Attesto.DPoP do
           htu: String.t(),
           iat: non_neg_integer(),
           jkt: String.t(),
-          jti: String.t()
+          jti: String.t(),
+          replay_ttl: pos_integer()
         }
 
   @type verify_error ::
@@ -205,7 +206,12 @@ defmodule Attesto.DPoP do
          htu: claims["htu"],
          iat: iat,
          jkt: JOSE.JWK.thumbprint(jwk),
-         jti: jti
+         jti: jti,
+         # The window this proof's `jti` must be remembered for, so a caller
+         # that claims the identifier itself - rather than through
+         # `:replay_check` here - uses the same acceptance window this
+         # verification applied instead of deriving it a second time.
+         replay_ttl: replay_ttl(opts)
        }}
     end
   end

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -178,6 +178,14 @@ defmodule Attesto.DPoP do
       `cnf.jkt`.
     * `{:error, reason}` otherwise. See the module typespecs for the full
       error set.
+
+  The success map carries `jkt` (the RFC 7638 thumbprint of the proof key),
+  `jti`, `iat`, `htm`, `htu`, `ath` (or `nil`), and `replay_ttl` - the
+  acceptance window this verification derived, for a caller that claims the
+  `jti` itself rather than through `:replay_check` (as
+  `Attesto.Plug.Authenticate` does, to avoid claiming for a request whose
+  token has not yet verified). Keys may be added in a minor release, so
+  match the ones you need rather than the whole map.
   """
   @spec verify_proof(String.t(), verify_opts()) ::
           {:ok, verified_proof()} | {:error, verify_error()}

--- a/lib/attesto/dpop/replay_cache.ex
+++ b/lib/attesto/dpop/replay_cache.ex
@@ -20,10 +20,17 @@ defmodule Attesto.DPoP.ReplayCache do
   given access token reaches the same node - otherwise a captured proof
   is replayable once per node behind a load balancer. On a multi-node
   deployment you MUST swap the verifier's `:replay_check` callback for a
-  shared-store implementation (e.g. a Postgres-backed cache using
-  `INSERT ... ON CONFLICT DO NOTHING` for an atomic record-and-check, or
-  Redis) and set `:multi_node_acknowledged?: true` to silence the
-  boot-time guard. The verifier's `:replay_check` shape
+  shared-store implementation and set `:multi_node_acknowledged?: true` to
+  silence the boot-time guard.
+
+  **`AttestoPhoenix.Store.EctoReplayCheck` is that implementation** if you
+  run `attesto_phoenix`: one relational table whose unique constraint on
+  `jti` makes the record-and-check atomic across every node, with a
+  matching schema and expiry sweeper. Reach for it before writing your own.
+  Any other shared store (Redis, or another database using
+  `INSERT ... ON CONFLICT DO NOTHING`) works too - the `:replay_check`
+  shape (`(jti, ttl_seconds) -> :ok | {:error, :replay}`) lets any
+  replacement plug in without changes to `Attesto.DPoP`. The verifier's `:replay_check` shape
   (`(jti, ttl_seconds) -> :ok | {:error, :replay}`) lets any such
   replacement plug in without changes to `Attesto.DPoP`. The verifier
   passes its own `:max_age_seconds` as `ttl_seconds`, so a shared store

--- a/lib/attesto/dpop/replay_cache.ex
+++ b/lib/attesto/dpop/replay_cache.ex
@@ -43,12 +43,28 @@ defmodule Attesto.DPoP.ReplayCache do
   refuses to enter. Failing the supervised start surfaces the
   misconfiguration loudly rather than emitting a log nobody reads.
 
+  ## Retention is per entry, not per cache
+
+  How long a `jti` is remembered is decided by the caller, not by this
+  process: `check_and_record/2` takes the TTL as an argument and stamps it
+  onto the entry. `Attesto.DPoP.verify_proof/2` passes its whole acceptance
+  window, so retention tracks the verifier's freshness policy automatically
+  and a `jti` cannot be forgotten while a proof carrying it would still be
+  accepted.
+
+  There is deliberately no `:ttl_seconds` start option. One would be a
+  cache-wide value that `check_and_record/2` has no way to consult - it is
+  a plain function, not a call into this GenServer - so it could only ever
+  disagree with the TTL the verifier actually supplies.
+
+  `check_and_record/1` exists for a caller with no verifier to take the
+  window from, and falls back to 60 seconds. Prefer
+  the two-arity form: a caller that defers the claim itself (as
+  `Attesto.Plug.Authenticate` does) should pass the `replay_ttl` that
+  `verify_proof/2` returned, so the two agree by construction.
+
   ## Configuration (start options)
 
-    * `:ttl_seconds` (default `60`) - how long each `jti` is remembered.
-      SHOULD match (or modestly exceed) the verifier's `:max_age_seconds`
-      so a proof whose `iat` window has already closed is rejected by
-      freshness OR by replay, never just by eviction race.
     * `:sweep_interval_ms` (default `30_000`) - how often expired entries
       are deleted in bulk. The cache is correct without sweeping (lookups
       re-validate expiry); the sweeper just bounds table size.
@@ -59,7 +75,7 @@ defmodule Attesto.DPoP.ReplayCache do
   ## Wiring
 
       children = [
-        {Attesto.DPoP.ReplayCache, ttl_seconds: 60}
+        Attesto.DPoP.ReplayCache
       ]
 
   then, at the verifier:

--- a/lib/attesto/dpop/replay_cache.ex
+++ b/lib/attesto/dpop/replay_cache.ex
@@ -30,11 +30,11 @@ defmodule Attesto.DPoP.ReplayCache do
   Any other shared store (Redis, or another database using
   `INSERT ... ON CONFLICT DO NOTHING`) works too - the `:replay_check`
   shape (`(jti, ttl_seconds) -> :ok | {:error, :replay}`) lets any
-  replacement plug in without changes to `Attesto.DPoP`. The verifier's `:replay_check` shape
-  (`(jti, ttl_seconds) -> :ok | {:error, :replay}`) lets any such
   replacement plug in without changes to `Attesto.DPoP`. The verifier
-  passes its own `:max_age_seconds` as `ttl_seconds`, so a shared store
-  can size each `jti`'s retention to the proof's freshness window.
+  passes its whole acceptance window as `ttl_seconds` - `:max_age_seconds`
+  plus the future-skew allowance it also tolerates, not `:max_age_seconds`
+  alone - so a shared store sized by that value cannot forget a `jti`
+  while a proof carrying it would still be accepted.
 
   The boot-time guard **raises** on startup if `Node.list/0` is non-empty
   and `:multi_node_acknowledged?` is not set - a clustered BEAM with a

--- a/lib/attesto/plug/authenticate.ex
+++ b/lib/attesto/plug/authenticate.ex
@@ -356,9 +356,14 @@ if Code.ensure_loaded?(Plug.Conn) do
     # `claim_dpop_jti/3` once the access token has verified. Nothing about the
     # guarantee changes: the claim still happens before the request is served,
     # it is still the same atomic check-and-record, and a replayed `jti` on an
-    # otherwise-valid request is still refused (RFC 9449 §11.1). What changes
-    # is that a request which was never going to be served no longer leaves a
-    # trace behind.
+    # otherwise-valid request is still refused (RFC 9449 §11.1).
+    #
+    # What changes is the population that can write: a caller must now present
+    # a token this server issued before its proof costs the store anything.
+    # The claim is deliberately NOT deferred past that point - a request that
+    # authenticates and is then refused a step-up challenge (RFC 9470) has
+    # still had its proof claimed, because by then the proof HAS been used
+    # against a valid token and must not be replayable.
     defp verify_dpop_proof(conn, proof, token, opts) do
       if replay_protected?(opts) do
         verify_opts =
@@ -382,10 +387,29 @@ if Code.ensure_loaded?(Plug.Conn) do
     defp claim_dpop_jti(jti, ttl_seconds, opts) when is_binary(jti) do
       case Keyword.get(opts, :replay_check) do
         fun when is_function(fun, 2) ->
+          # The accepted results mirror `Attesto.DPoP.check_replay/2` exactly.
+          # Accepting any `{:error, _}` here would turn a replay-store outage
+          # (`{:error, :unavailable}` from a host's shared store, say) into a
+          # 401 `invalid_dpop_proof`, blaming the client for a server fault and
+          # hiding the outage. An unsupported return is a host integration bug
+          # and is raised, not translated.
           case fun.(jti, ttl_seconds) do
-            :ok -> :ok
-            {:error, reason} -> {:dpop_error, reason}
-            other -> {:dpop_error, other}
+            :ok ->
+              :ok
+
+            {:error, :replay} ->
+              # RFC 9449 §11.1. Emitted here rather than in
+              # `Attesto.DPoP.check_replay/2`, because this plug deliberately
+              # does not hand `:replay_check` to `verify_proof/2` - the claim
+              # is deferred until the token has verified - so the core's
+              # emission point is never reached on this path.
+              Attesto.Telemetry.dpop_replay_detected(jti)
+              {:dpop_error, :replay}
+
+            other ->
+              raise ArgumentError,
+                    "Attesto.Plug.Authenticate :replay_check must return :ok or {:error, :replay}; " <>
+                      "got #{inspect(other)}"
           end
 
         _ ->

--- a/lib/attesto/plug/authenticate.ex
+++ b/lib/attesto/plug/authenticate.ex
@@ -129,10 +129,15 @@ if Code.ensure_loaded?(Plug.Conn) do
     def call(conn, opts) do
       config = resolve_config(opts)
 
+      # The DPoP proof is verified before the token (its `jkt` is an input to
+      # token verification), but its `jti` is claimed only after - see
+      # `verify_dpop_proof/4`. Claiming earlier would let an unauthenticated
+      # request write to the replay store.
       with {:ok, scheme, token} <- authorization(conn, opts),
-           {:ok, dpop_jkt} <- verify_dpop(conn, scheme, token, opts),
+           {:ok, dpop_jkt, dpop_jti, replay_ttl} <- verify_dpop(conn, scheme, token, opts),
            {:ok, mtls_thumb} <- cert_thumbprint(conn, opts),
-           {:ok, claims} <- verify_token(config, token, dpop_jkt, mtls_thumb, opts) do
+           {:ok, claims} <- verify_token(config, token, dpop_jkt, mtls_thumb, opts),
+           :ok <- claim_dpop_jti(dpop_jti, replay_ttl, opts) do
         conn = assign(conn, Keyword.get(opts, :claims_key, @default_claims_key), claims)
 
         # RFC 9470 §3: after the token is verified, enforce any route step-up
@@ -325,7 +330,7 @@ if Code.ensure_loaded?(Plug.Conn) do
     defp verify_dpop(conn, :bearer, _token, _opts) do
       case get_req_header(conn, "dpop") do
         [_ | _] -> {:dpop_error, :dpop_scheme_required}
-        _ -> {:ok, nil}
+        _ -> {:ok, nil, nil, nil}
       end
     end
 
@@ -337,19 +342,57 @@ if Code.ensure_loaded?(Plug.Conn) do
     # acknowledged running unprotected. This is scoped to DPoP requests, so
     # a Bearer/mTLS-only deployment is never forced to provide a replay
     # store it has no use for.
+    # The proof is validated here but its `jti` is NOT yet claimed, and the
+    # ordering is deliberate. `:replay_check` is a check-AND-record operation:
+    # the default (`Attesto.DPoP.ReplayCache.check_and_record/2`) claims the
+    # identifier with `:ets.insert_new/2` in the same step that tests it.
+    # Running it during proof validation would mean an unauthenticated caller
+    # writes a row on every request: a DPoP proof is signed by a key the caller
+    # generated, so anyone can mint a valid one, pair it with any string in the
+    # `Authorization` header, and grow an unbounded table for the cost of a
+    # signature.
+    #
+    # So the `jti` travels out of here unclaimed and is claimed by
+    # `claim_dpop_jti/3` once the access token has verified. Nothing about the
+    # guarantee changes: the claim still happens before the request is served,
+    # it is still the same atomic check-and-record, and a replayed `jti` on an
+    # otherwise-valid request is still refused (RFC 9449 §11.1). What changes
+    # is that a request which was never going to be served no longer leaves a
+    # trace behind.
     defp verify_dpop_proof(conn, proof, token, opts) do
       if replay_protected?(opts) do
         verify_opts =
           [http_method: conn.method, http_uri: htu(conn, opts), access_token: token]
-          |> put_opt(:replay_check, Keyword.get(opts, :replay_check))
           |> put_opt(:nonce_check, Keyword.get(opts, :nonce_check))
 
         case DPoP.verify_proof(proof, verify_opts) do
-          {:ok, %{jkt: jkt}} -> {:ok, jkt}
+          {:ok, %{jkt: jkt, jti: jti, replay_ttl: ttl}} -> {:ok, jkt, jti, ttl}
           {:error, reason} -> {:dpop_error, reason}
         end
       else
         {:dpop_error, :replay_check_unconfigured}
+      end
+    end
+
+    # Claim the proof identifier, now that the token behind it is known to be
+    # valid. A Bearer/mTLS request carries no proof and so has nothing to
+    # claim.
+    defp claim_dpop_jti(nil, _ttl, _opts), do: :ok
+
+    defp claim_dpop_jti(jti, ttl_seconds, opts) when is_binary(jti) do
+      case Keyword.get(opts, :replay_check) do
+        fun when is_function(fun, 2) ->
+          case fun.(jti, ttl_seconds) do
+            :ok -> :ok
+            {:error, reason} -> {:dpop_error, reason}
+            other -> {:dpop_error, other}
+          end
+
+        _ ->
+          # `replay_protected?/1` already allowed this request through on the
+          # host's explicit acknowledgement that it runs without replay
+          # protection.
+          :ok
       end
     end
 

--- a/lib/attesto/refresh_token.ex
+++ b/lib/attesto/refresh_token.ex
@@ -62,6 +62,7 @@ defmodule Attesto.RefreshToken do
   @type rotate_error ::
           :invalid_grant
           | :reuse_detected
+          | :grant_revoked
           | :expired
           | :client_required
           | :client_mismatch
@@ -286,8 +287,12 @@ defmodule Attesto.RefreshToken do
         # token presented ONCE. Emitting the reuse event for it would page
         # someone with "a credential has been stolen" over a logout, and an
         # alert that fires on routine behaviour is one people learn to close.
+        #
+        # The RETURN says the same thing: `:grant_revoked`, not
+        # `:reuse_detected`. A caller alerting on the atom would otherwise draw
+        # the conclusion the telemetry deliberately refuses to.
         :ok = store.revoke_family(claimed.family_id)
-        {:error, :reuse_detected}
+        {:error, :grant_revoked}
     end
   end
 

--- a/lib/attesto/refresh_token.ex
+++ b/lib/attesto/refresh_token.ex
@@ -275,10 +275,19 @@ defmodule Attesto.RefreshToken do
          }}
 
       {:error, :family_revoked} ->
-        # We won the atomic claim, but a concurrent reuse revoked the family
-        # before our successor landed: a concurrent double-use. Ensure the
-        # family is revoked and report it as reuse, not a fresh token.
-        revoke_and_report_reuse(store, claimed)
+        # We won the atomic claim, but the family was revoked before our
+        # successor landed. DENY on that - no successor is minted and the
+        # family stays revoked - but do NOT report it as reuse, because this
+        # branch does not know that it was.
+        #
+        # `store.revoke_family/1` is the same operation `Attesto.Revocation`
+        # performs for an ordinary RFC 7009 request or a logout, so a family
+        # can be revoked here by a user signing out mid-rotation. That is a
+        # token presented ONCE. Emitting the reuse event for it would page
+        # someone with "a credential has been stolen" over a logout, and an
+        # alert that fires on routine behaviour is one people learn to close.
+        :ok = store.revoke_family(claimed.family_id)
+        {:error, :reuse_detected}
     end
   end
 

--- a/lib/attesto/refresh_token.ex
+++ b/lib/attesto/refresh_token.ex
@@ -185,22 +185,36 @@ defmodule Attesto.RefreshToken do
          context: successor.context
        }}
     else
-      _ ->
-        :ok = store.revoke_family(record.family_id)
-
-        # The family is now revoked, so the legitimate client's session is
-        # over either way. This event is the only notice anyone gets that it
-        # ended because a token was presented twice rather than because a user
-        # logged out - see `Attesto.Telemetry`.
-        Attesto.Telemetry.refresh_token_reuse_detected(%{
-          family_id: record.family_id,
-          client_id: Map.get(record.data, :client_id),
-          subject: Map.get(record.data, :subject),
-          generation: Map.get(record, :generation)
-        })
-
-        {:error, :reuse_detected}
+      _ -> revoke_and_report_reuse(store, record)
     end
+  end
+
+  # EVERY path that concludes "this token was presented twice" goes through
+  # here, so revoking the family and reporting it cannot drift apart.
+  #
+  # There are three such paths and they are not interchangeable in how they
+  # were reached: the initial read finds an already-consumed token, the atomic
+  # `consume` reports `{:reuse, _}` against a concurrent rotation, or our own
+  # claim succeeds and then finds the family revoked underneath it. The first
+  # is a lone late retry; the other two are a live race, which is the shape an
+  # attacker racing the legitimate client actually produces. Instrumenting only
+  # the first would have left the concurrent cases - the ones that matter most -
+  # silent.
+  defp revoke_and_report_reuse(store, record) do
+    :ok = store.revoke_family(record.family_id)
+
+    # The family is now revoked, so the legitimate client's session is over
+    # either way. This event is the only notice anyone gets that it ended
+    # because a token was presented twice rather than because a user logged
+    # out - see `Attesto.Telemetry`.
+    Attesto.Telemetry.refresh_token_reuse_detected(%{
+      family_id: record.family_id,
+      client_id: record |> Map.get(:data, %{}) |> Map.get(:client_id),
+      subject: record |> Map.get(:data, %{}) |> Map.get(:subject),
+      generation: Map.get(record, :generation)
+    })
+
+    {:error, :reuse_detected}
   end
 
   # OAuth 2.0 Security BCP §4.13.2: the rotation-grace idempotent retry is safe
@@ -264,8 +278,7 @@ defmodule Attesto.RefreshToken do
         # We won the atomic claim, but a concurrent reuse revoked the family
         # before our successor landed: a concurrent double-use. Ensure the
         # family is revoked and report it as reuse, not a fresh token.
-        :ok = store.revoke_family(claimed.family_id)
-        {:error, :reuse_detected}
+        revoke_and_report_reuse(store, claimed)
     end
   end
 
@@ -336,8 +349,7 @@ defmodule Attesto.RefreshToken do
         {:ok, claimed}
 
       {:reuse, claimed} ->
-        :ok = store.revoke_family(claimed.family_id)
-        {:error, :reuse_detected}
+        revoke_and_report_reuse(store, claimed)
 
       :error ->
         {:error, :invalid_grant}

--- a/lib/attesto/refresh_token.ex
+++ b/lib/attesto/refresh_token.ex
@@ -187,6 +187,18 @@ defmodule Attesto.RefreshToken do
     else
       _ ->
         :ok = store.revoke_family(record.family_id)
+
+        # The family is now revoked, so the legitimate client's session is
+        # over either way. This event is the only notice anyone gets that it
+        # ended because a token was presented twice rather than because a user
+        # logged out - see `Attesto.Telemetry`.
+        Attesto.Telemetry.refresh_token_reuse_detected(%{
+          family_id: record.family_id,
+          client_id: Map.get(record.data, :client_id),
+          subject: Map.get(record.data, :subject),
+          generation: Map.get(record, :generation)
+        })
+
         {:error, :reuse_detected}
     end
   end

--- a/lib/attesto/secure_compare.ex
+++ b/lib/attesto/secure_compare.ex
@@ -9,17 +9,33 @@ defmodule Attesto.SecureCompare do
 
   @doc """
   Returns `true` iff `a` and `b` are byte-identical, comparing in
-  constant time.
+  constant time **regardless of their lengths**.
 
-  `:crypto.hash_equals/2` requires equal-length inputs, and at least one
-  operand here is attacker-controlled, so the length is gated first. The
-  length check is not itself timing-sensitive in the cases this is used
-  for: the operands are fixed-length base64url digests, so a length
-  mismatch only ever means a malformed input, not a near-miss secret.
+  `:crypto.hash_equals/2` requires equal-length inputs, so a length guard
+  is unavoidable somewhere. Guarding with `byte_size(a) == byte_size(b)`
+  before it would short-circuit, and the time to answer would then
+  separate "wrong length" from "right length, wrong bytes". Comparing
+  fixed-size digests of the operands removes that: both inputs are hashed
+  to 32 bytes, so the comparison is over equal lengths by construction and
+  its duration carries nothing about the inputs.
+
+  Every call site inside this library already guarantees fixed-length
+  operands before calling (`Attesto.PKCE.verify/3` gates on
+  `Attesto.Thumbprint.valid?/1`, which requires an exact byte size), so
+  this is not a fix for a leak in Attesto's own use. It is here because
+  this function is public, its name is an unconditional promise, and a
+  host comparing a variable-length value of its own should get the
+  property the name claims rather than one contingent on validating shape
+  first.
+
+  The final byte comparison runs only when the digests already match, so
+  it cannot leak: reaching it means the caller supplied either the correct
+  value or a SHA-256 collision. It is there so a collision cannot be
+  reported as equality.
   """
   @spec equal?(binary(), binary()) :: boolean()
   def equal?(a, b) when is_binary(a) and is_binary(b) do
-    byte_size(a) == byte_size(b) and :crypto.hash_equals(a, b)
+    :crypto.hash_equals(:crypto.hash(:sha256, a), :crypto.hash(:sha256, b)) and a == b
   end
 
   def equal?(_, _), do: false

--- a/lib/attesto/secure_compare.ex
+++ b/lib/attesto/secure_compare.ex
@@ -8,30 +8,37 @@ defmodule Attesto.SecureCompare do
   """
 
   @doc """
-  Returns `true` iff `a` and `b` are byte-identical, comparing in
-  constant time **regardless of their lengths**.
+  Returns `true` iff `a` and `b` are byte-identical, without the
+  *comparison* revealing whether they were the same length.
 
   `:crypto.hash_equals/2` requires equal-length inputs, so a length guard
   is unavoidable somewhere. Guarding with `byte_size(a) == byte_size(b)`
-  before it would short-circuit, and the time to answer would then
-  separate "wrong length" from "right length, wrong bytes". Comparing
-  fixed-size digests of the operands removes that: both inputs are hashed
-  to 32 bytes, so the comparison is over equal lengths by construction and
-  its duration carries nothing about the inputs.
+  before it short-circuits, and the time to answer then separates "wrong
+  length" from "right length, wrong bytes" - a distinction that tells an
+  attacker probing a secret when to stop varying length and start varying
+  content. Hashing both operands to 32 bytes removes it: the comparison is
+  over equal lengths by construction and takes the same path either way.
 
-  Every call site inside this library already guarantees fixed-length
-  operands before calling (`Attesto.PKCE.verify/3` gates on
-  `Attesto.Thumbprint.valid?/1`, which requires an exact byte size), so
-  this is not a fix for a leak in Attesto's own use. It is here because
-  this function is public, its name is an unconditional promise, and a
-  host comparing a variable-length value of its own should get the
-  property the name claims rather than one contingent on validating shape
-  first.
+  ## What this does not do
+
+  It is **not** constant-time in the total size of its inputs. SHA-256
+  reads every byte, so a call with two 100 KB operands takes materially
+  longer than one with two 1-byte operands. What is withheld is the
+  *result-dependent* signal - whether a guess was the right length, or
+  matched to some prefix - not the fact that a large value was compared.
+  A caller who needs the size itself hidden must pad or cap before calling.
+
+  Callers should still validate shape first where they can, and most here
+  do: `Attesto.PKCE.verify/3` gates on `Attesto.Thumbprint.valid?/1`,
+  which requires an exact byte size, so its operands are fixed-length
+  before this is reached. `Attesto.DPoP`'s `ath` comparison does not - the
+  presented value is an arbitrary-length claim from the proof - which is
+  precisely the case that benefits.
 
   The final byte comparison runs only when the digests already match, so
-  it cannot leak: reaching it means the caller supplied either the correct
-  value or a SHA-256 collision. It is there so a collision cannot be
-  reported as equality.
+  it carries no result-dependent signal: reaching it means the caller
+  supplied either the correct value or a SHA-256 collision. It is there so
+  a collision cannot be reported as equality.
   """
   @spec equal?(binary(), binary()) :: boolean()
   def equal?(a, b) when is_binary(a) and is_binary(b) do

--- a/lib/attesto/secure_compare.ex
+++ b/lib/attesto/secure_compare.ex
@@ -1,10 +1,15 @@
 defmodule Attesto.SecureCompare do
   @moduledoc """
-  Constant-time comparison of two binaries.
+  Result-independent comparison of two binaries.
 
   Used wherever an attacker-controlled value is checked against a secret
   or a derived digest (a DPoP `ath`, a PKCE challenge) and a
   short-circuiting `==` would leak information through timing.
+
+  "Result-independent" rather than "constant-time": how long `equal?/2`
+  takes does not depend on HOW the operands differ - whether the length was
+  wrong, or a prefix matched - but it does depend on their total size, since
+  both are hashed. See `equal?/2` for what that does and does not withhold.
   """
 
   @doc """

--- a/lib/attesto/secure_compare.ex
+++ b/lib/attesto/secure_compare.ex
@@ -40,10 +40,13 @@ defmodule Attesto.SecureCompare do
   presented value is an arbitrary-length claim from the proof - which is
   precisely the case that benefits.
 
-  The final byte comparison runs only when the digests already match, so
-  it carries no result-dependent signal: reaching it means the caller
-  supplied either the correct value or a SHA-256 collision. It is there so
-  a collision cannot be reported as equality.
+  The final byte comparison runs only when the digests already match, which
+  IS a result-dependent branch - an equal pair does that extra work and an
+  unequal pair does not. It is deliberate and it leaks nothing useful:
+  reaching it means the caller already supplied the correct value (or a
+  SHA-256 collision), so the timing difference separates "right" from
+  "wrong", which the answer itself already reveals. What is withheld is the
+  distinction among WRONG inputs - the one an attacker probes with.
   """
   @spec equal?(binary(), binary()) :: boolean()
   def equal?(a, b) when is_binary(a) and is_binary(b) do

--- a/lib/attesto/session_state.ex
+++ b/lib/attesto/session_state.ex
@@ -146,7 +146,11 @@ defmodule Attesto.SessionState do
       browser state MUST rotate (Session Management 1.0 §3.2) and any earlier
       RP `session_state` becomes `changed`.
 
-  Both comparisons are constant-time.
+  Both comparisons go through `Attesto.SecureCompare.equal?/2`, so neither
+  reveals HOW the presented value differs - wrong length, or right length and
+  wrong bytes, take the same path. The segments come from an attacker-supplied
+  string and are not length-validated first, so the time taken still varies
+  with how much was submitted; see that module for the distinction.
   """
   @spec browser_state_valid?(binary(), binary(), binary()) :: boolean()
   def browser_state_valid?(secret, value, login_binding)

--- a/lib/attesto/telemetry.ex
+++ b/lib/attesto/telemetry.ex
@@ -1,0 +1,137 @@
+defmodule Attesto.Telemetry do
+  @moduledoc """
+  `:telemetry` events Attesto emits for security-relevant refusals.
+
+  These events exist for one reason: some refusals are not routine. A
+  refresh token presented twice, or a DPoP proof whose `jti` has already
+  been seen, is evidence that someone holds a credential they should not.
+  A return value tells the calling function; it does not tell whoever is
+  on call. Attaching a handler to these events is how that signal reaches
+  a pager, a SIEM, or an audit log without a host wrapping every call site.
+
+  Ordinary failures are deliberately NOT events. An expired token, an
+  unknown client, a wrong scope - these happen constantly in healthy
+  traffic, and emitting them would bury the three below in noise.
+
+  ## Events
+
+  Every event carries `%{system_time: System.system_time()}` as its
+  measurements and is emitted at the moment the refusal is decided.
+
+  ### `[:attesto, :refresh_token, :reuse_detected]`
+
+  A refresh token was presented after it had already been rotated, outside
+  the idempotency window or without matching the original client, binding,
+  and scope (RFC 6749 §10.4, RFC 9700 §4.14). **The whole family has been
+  revoked** by the time this fires, so the legitimate client's session is
+  already over; this event is the only notice anyone gets that it was not
+  an ordinary logout.
+
+  This is the highest-value event here. Treat it as an alert, not a log
+  line.
+
+  Metadata:
+
+    * `:family_id` - the revoked family, for correlating the sessions this
+      terminated.
+    * `:client_id` - the client the family was issued to, when the token
+      carried one.
+    * `:subject` - the resource owner whose session was revoked.
+    * `:generation` - the generation of the presented token.
+
+  ### `[:attesto, :dpop, :replay_detected]`
+
+  A DPoP proof carried a `jti` the replay store had already recorded
+  (RFC 9449 §11.1) - the proof was captured and replayed, or a client is
+  reusing identifiers it must not.
+
+  Metadata:
+
+    * `:jti` - the replayed identifier. Not a credential: it travels in
+      the proof and is the only handle for correlating repeats.
+
+  ### `[:attesto, :token, :sender_constraint_mismatch]`
+
+  A token bound to a sender was presented with the wrong proof of
+  possession, or with none: a DPoP-bound token under a mismatched key
+  (RFC 9449 §7.1), or an mTLS-bound token with a mismatched certificate
+  (RFC 8705 §3). The most likely explanation is a token that has left the
+  holder it was issued to.
+
+  Metadata:
+
+    * `:binding` - `:dpop` or `:mtls`, the constraint that failed.
+    * `:reason` - the specific refusal (`:dpop_binding_mismatch` or
+      `:mtls_binding_mismatch`).
+    * `:client_id` - the `client_id` claim of the presented token, when it
+      carries one.
+
+  ## What metadata never contains
+
+  No access token, refresh token, authorization code, client secret, DPoP
+  proof, or assertion - in plaintext or hashed. A handler writing metadata
+  straight to a log must not thereby write a credential to disk. The
+  identifiers above (`family_id`, `jti`, `client_id`, `subject`) are
+  correlation handles, not secrets, and none of them can be presented to
+  obtain anything.
+
+  ## Attaching
+
+      :telemetry.attach_many(
+        "attesto-security",
+        [
+          [:attesto, :refresh_token, :reuse_detected],
+          [:attesto, :dpop, :replay_detected],
+          [:attesto, :token, :sender_constraint_mismatch]
+        ],
+        &MyApp.Security.handle_event/4,
+        nil
+      )
+
+  ## Stability
+
+  These names and metadata keys are public API and follow this package's
+  version policy: keys may be added, but an existing event will not be
+  renamed or have a documented key removed without a major version.
+  """
+
+  @refresh_token_reuse [:attesto, :refresh_token, :reuse_detected]
+  @dpop_replay [:attesto, :dpop, :replay_detected]
+  @sender_constraint_mismatch [:attesto, :token, :sender_constraint_mismatch]
+
+  @doc "Every event this library emits, for `:telemetry.attach_many/4`."
+  @spec events() :: [[atom()]]
+  def events, do: [@refresh_token_reuse, @dpop_replay, @sender_constraint_mismatch]
+
+  @doc false
+  @spec refresh_token_reuse_detected(map()) :: :ok
+  def refresh_token_reuse_detected(metadata) when is_map(metadata) do
+    emit(@refresh_token_reuse, metadata)
+  end
+
+  @doc false
+  @spec dpop_replay_detected(String.t()) :: :ok
+  def dpop_replay_detected(jti) when is_binary(jti) do
+    emit(@dpop_replay, %{jti: jti})
+  end
+
+  @doc false
+  @spec sender_constraint_mismatch(:dpop | :mtls, atom(), map()) :: :ok
+  def sender_constraint_mismatch(binding, reason, claims) when is_map(claims) do
+    emit(@sender_constraint_mismatch, %{
+      binding: binding,
+      reason: reason,
+      client_id: Map.get(claims, "client_id")
+    })
+  end
+
+  # A handler that raises must not take the request down with it: these are
+  # refusals, and the refusal itself is the security-relevant outcome.
+  # `:telemetry.execute/3` already detaches a failing handler rather than
+  # propagating, so this only guards the emit call itself.
+  defp emit(event, metadata) do
+    :telemetry.execute(event, %{system_time: System.system_time()}, metadata)
+  catch
+    _kind, _reason -> :ok
+  end
+end

--- a/lib/attesto/telemetry.ex
+++ b/lib/attesto/telemetry.ex
@@ -118,7 +118,16 @@ defmodule Attesto.Telemetry do
 
   So treat metadata as untrusted, attacker-influencable input on its way to
   wherever the handler sends it: escape it, bound it, and do not
-  interpolate it into anything that parses.
+  interpolate it into anything that parses. A client that puts its own live
+  secret in `jti` will have that secret written wherever the handler writes.
+
+  ## Handlers run synchronously
+
+  `:telemetry` invokes handlers on the calling process, so a handler that
+  blocks blocks the refusal that produced the event, and there is no timeout.
+  Hand work to a queue, a task, or a `GenServer` and return; do not do I/O
+  inline. A handler that raises or exits is caught and detached by
+  `:telemetry` itself and cannot change the outcome - one that hangs can.
 
   ## Attaching
 
@@ -177,12 +186,17 @@ defmodule Attesto.Telemetry do
   # handler, and this function does not need to protect against one.
   #
   # What a blanket `catch _kind, _reason` DID protect against was the dispatcher
-  # itself failing, and it did so by swallowing the failure whole. With
-  # `:telemetry` stopped, this returned `:ok` having delivered nothing: the
-  # library reported success for an alert nobody received. For events whose
-  # entire purpose is to tell an operator a credential may be stolen, silently
-  # losing one is worse than a loud failure, and it cannot be noticed later
-  # because a missing event leaves no trace.
+  # itself failing, and it did so by swallowing the failure whole.
+  #
+  # Removing it does not make every loss loud, and it is worth being exact:
+  # with `:telemetry` stopped, `execute/3` finds an empty handler list and
+  # returns `:ok`, so that particular loss is still silent. What the removal
+  # buys is that a genuine dispatch failure surfaces instead of being absorbed.
+  #
+  # Delivery is SYNCHRONOUS and best-effort. A handler that blocks blocks the
+  # refusal with it - `:telemetry` offers no timeout - so a handler must hand
+  # work off and return promptly. That is a contract on the host, stated in the
+  # moduledoc, not something this function can enforce.
   defp emit(event, metadata) do
     :telemetry.execute(event, %{system_time: System.system_time()}, metadata)
   end

--- a/lib/attesto/telemetry.ex
+++ b/lib/attesto/telemetry.ex
@@ -4,14 +4,33 @@ defmodule Attesto.Telemetry do
 
   These events exist for one reason: some refusals are not routine. A
   refresh token presented twice, or a DPoP proof whose `jti` has already
-  been seen, is evidence that someone holds a credential they should not.
-  A return value tells the calling function; it does not tell whoever is
-  on call. Attaching a handler to these events is how that signal reaches
-  a pager, a SIEM, or an audit log without a host wrapping every call site.
+  been seen, is the shape a stolen credential makes. A return value tells
+  the calling function; it does not tell whoever is on call. Attaching a
+  handler is how that signal reaches a pager, a SIEM, or an audit log
+  without a host wrapping every call site.
 
   Ordinary failures are deliberately NOT events. An expired token, an
   unknown client, a wrong scope - these happen constantly in healthy
   traffic, and emitting them would bury the three below in noise.
+
+  ## These are indicators, not verdicts
+
+  None of them proves theft, and two are cheap for a client to produce
+  deliberately:
+
+    * A client can present its own sender-bound token under a second key as
+      often as it likes. Verification fails before the proof's `jti` is
+      claimed, so the same proof works repeatedly - one token and one proof
+      can ring `sender_constraint_mismatch` indefinitely.
+    * A mid-rotation key or certificate rotation, or a client with a stale
+      cached key, produces the same mismatch for entirely benign reasons.
+
+  So treat them as inputs to a decision rather than the decision:
+  rate-limit and deduplicate by `client_id` before alerting, correlate
+  across events and requests, and page on a pattern rather than on a single
+  occurrence. `refresh_token.reuse_detected` is the one worth escalating
+  fastest, because reaching it has already revoked the family - the damage
+  it reports is done either way.
 
   ## Events
 
@@ -55,9 +74,13 @@ defmodule Attesto.Telemetry do
 
   A token bound to a sender was presented with the WRONG proof of
   possession: a DPoP-bound token under a mismatched key (RFC 9449 §7.1),
-  or an mTLS-bound token with a mismatched certificate (RFC 8705 §3). The
-  most likely explanation is a token that has left the holder it was
-  issued to.
+  or an mTLS-bound token with a mismatched certificate (RFC 8705 §3).
+
+  This is the weakest of the three. A token separated from its holder
+  produces it - but so does a key rotation, a stale cached key, and a
+  client that simply chooses to send the wrong one, repeatedly and for
+  free. Correlate before concluding anything; see "indicators, not
+  verdicts" above.
 
   A *missing* proof (`:dpop_proof_required`, `:mtls_cert_required`) does
   not emit. A client that has not implemented DPoP yet produces those
@@ -73,13 +96,14 @@ defmodule Attesto.Telemetry do
 
   ## What metadata contains, and what it does not
 
-  Attesto never *derives* metadata from a credential: it does not put an
-  access token, refresh token, authorization code, client secret, DPoP
-  proof, or assertion into an event, in plaintext or hashed, and none of
-  the values it chooses itself can be presented to obtain anything.
+  Attesto never copies a credential, or a digest of one, into an event: no
+  access token, refresh token, authorization code, client secret, assertion,
+  or DPoP proof appears in metadata, and nothing emitted can be presented to
+  obtain anything.
 
-  That is not a promise that the bytes are harmless, because some of them
-  are not Attesto's to choose:
+  It does emit selected FIELDS taken from credentials - `jti` is read out of
+  the DPoP proof, `client_id` out of the presented token's claims - and
+  those fields carry whatever their author put in them:
 
     * **`jti` is chosen by the client.** RFC 9449 constrains it only to be
       a unique string; this verifier additionally caps it at 256 bytes. A
@@ -146,13 +170,20 @@ defmodule Attesto.Telemetry do
     })
   end
 
-  # A handler that raises must not take the request down with it: these are
-  # refusals, and the refusal itself is the security-relevant outcome.
-  # `:telemetry.execute/3` already detaches a failing handler rather than
-  # propagating, so this only guards the emit call itself.
+  # No catch here, deliberately.
+  #
+  # A handler that raises is already handled: `:telemetry.execute/3` catches it,
+  # detaches the handler, and logs - so the refusal is never taken down by a bad
+  # handler, and this function does not need to protect against one.
+  #
+  # What a blanket `catch _kind, _reason` DID protect against was the dispatcher
+  # itself failing, and it did so by swallowing the failure whole. With
+  # `:telemetry` stopped, this returned `:ok` having delivered nothing: the
+  # library reported success for an alert nobody received. For events whose
+  # entire purpose is to tell an operator a credential may be stolen, silently
+  # losing one is worse than a loud failure, and it cannot be noticed later
+  # because a missing event leaves no trace.
   defp emit(event, metadata) do
     :telemetry.execute(event, %{system_time: System.system_time()}, metadata)
-  catch
-    _kind, _reason -> :ok
   end
 end

--- a/lib/attesto/telemetry.ex
+++ b/lib/attesto/telemetry.ex
@@ -47,8 +47,9 @@ defmodule Attesto.Telemetry do
 
   Metadata:
 
-    * `:jti` - the replayed identifier. Not a credential: it travels in
-      the proof and is the only handle for correlating repeats.
+    * `:jti` - the replayed identifier, emitted unchanged because it is the
+      only handle for correlating repeats. Chosen by the CLIENT, so see
+      "What metadata contains" below before writing it anywhere.
 
   ### `[:attesto, :token, :sender_constraint_mismatch]`
 
@@ -72,13 +73,13 @@ defmodule Attesto.Telemetry do
 
   ## What metadata contains, and what it does not
 
-  Attesto never *puts* a credential in metadata: no access token, refresh
-  token, authorization code, client secret, DPoP proof, or assertion, in
-  plaintext or hashed. None of the values emitted can be presented to
-  obtain anything.
+  Attesto never *derives* metadata from a credential: it does not put an
+  access token, refresh token, authorization code, client secret, DPoP
+  proof, or assertion into an event, in plaintext or hashed, and none of
+  the values it chooses itself can be presented to obtain anything.
 
-  That is a statement about this library, not about the bytes that end up
-  in your logs, and the difference matters:
+  That is not a promise that the bytes are harmless, because some of them
+  are not Attesto's to choose:
 
     * **`jti` is chosen by the client.** RFC 9449 constrains it only to be
       a unique string; this verifier additionally caps it at 256 bytes. A

--- a/lib/attesto/telemetry.ex
+++ b/lib/attesto/telemetry.ex
@@ -52,11 +52,15 @@ defmodule Attesto.Telemetry do
 
   ### `[:attesto, :token, :sender_constraint_mismatch]`
 
-  A token bound to a sender was presented with the wrong proof of
-  possession, or with none: a DPoP-bound token under a mismatched key
-  (RFC 9449 §7.1), or an mTLS-bound token with a mismatched certificate
-  (RFC 8705 §3). The most likely explanation is a token that has left the
-  holder it was issued to.
+  A token bound to a sender was presented with the WRONG proof of
+  possession: a DPoP-bound token under a mismatched key (RFC 9449 §7.1),
+  or an mTLS-bound token with a mismatched certificate (RFC 8705 §3). The
+  most likely explanation is a token that has left the holder it was
+  issued to.
+
+  A *missing* proof (`:dpop_proof_required`, `:mtls_cert_required`) does
+  not emit. A client that has not implemented DPoP yet produces those
+  constantly, and they say nothing about where the token is.
 
   Metadata:
 
@@ -66,14 +70,30 @@ defmodule Attesto.Telemetry do
     * `:client_id` - the `client_id` claim of the presented token, when it
       carries one.
 
-  ## What metadata never contains
+  ## What metadata contains, and what it does not
 
-  No access token, refresh token, authorization code, client secret, DPoP
-  proof, or assertion - in plaintext or hashed. A handler writing metadata
-  straight to a log must not thereby write a credential to disk. The
-  identifiers above (`family_id`, `jti`, `client_id`, `subject`) are
-  correlation handles, not secrets, and none of them can be presented to
+  Attesto never *puts* a credential in metadata: no access token, refresh
+  token, authorization code, client secret, DPoP proof, or assertion, in
+  plaintext or hashed. None of the values emitted can be presented to
   obtain anything.
+
+  That is a statement about this library, not about the bytes that end up
+  in your logs, and the difference matters:
+
+    * **`jti` is chosen by the client.** RFC 9449 constrains it only to be
+      a unique string; this verifier additionally caps it at 256 bytes. A
+      client may put anything there, including something that looks like -
+      or is - one of its own credentials, and it is emitted unchanged so
+      repeats can be correlated. A handler that writes metadata to a log
+      is writing a remote party's chosen bytes to that log.
+    * **`client_id`, `subject`, and `family_id` come from the host.** They
+      are whatever the host's own identifiers are. `subject` in particular
+      is usually personal data and falls under whatever retention policy
+      covers your logs.
+
+  So treat metadata as untrusted, attacker-influencable input on its way to
+  wherever the handler sends it: escape it, bound it, and do not
+  interpolate it into anything that parses.
 
   ## Attaching
 

--- a/lib/attesto/token.ex
+++ b/lib/attesto/token.ex
@@ -737,8 +737,16 @@ defmodule Attesto.Token do
       cross != nil -> {:error, :mtls_cert_unexpected}
       presented == nil -> {:error, :dpop_proof_required}
       presented == bound -> :ok
-      true -> {:error, :dpop_binding_mismatch}
+      true -> sender_constraint_mismatch(:dpop, :dpop_binding_mismatch, claims)
     end
+  end
+
+  # A sender-bound token presented with the wrong proof of possession is the
+  # signature of a token that has left the holder it was issued to, so it is
+  # reported as well as refused (see `Attesto.Telemetry`).
+  defp sender_constraint_mismatch(binding, reason, claims) do
+    Attesto.Telemetry.sender_constraint_mismatch(binding, reason, claims)
+    {:error, reason}
   end
 
   defp check_mtls_pair(claims, opts) do
@@ -750,7 +758,7 @@ defmodule Attesto.Token do
       cross != nil -> {:error, :dpop_proof_unexpected}
       presented == nil -> {:error, :mtls_cert_required}
       presented == bound -> :ok
-      true -> {:error, :mtls_binding_mismatch}
+      true -> sender_constraint_mismatch(:mtls, :mtls_binding_mismatch, claims)
     end
   end
 

--- a/lib/attesto/token.ex
+++ b/lib/attesto/token.ex
@@ -278,7 +278,8 @@ defmodule Attesto.Token do
        audience. When a `:trusted_audiences` list is supplied, a scalar
        audience must be in that explicit set and every member of an array
        audience must be trusted. A resolver-backed audience decision is
-       deferred until every other token check succeeds.
+       deferred until every other check EXCEPT the binding (step 10) has
+       succeeded - see that step for why it goes last.
     5. **Temporal.** `exp` is strictly greater than `now` (no skew
        leeway). If `nbf` is present it MUST be an integer no later than
        `now` (RFC 7519 §4.1.5; a small clock-skew tolerance applies), else
@@ -299,6 +300,14 @@ defmodule Attesto.Token do
        token requires neither. The cross-scheme option MUST be absent.
        See the error list for the precise outcomes.
 
+       This runs LAST, after a resolver-backed audience decision, because a
+       binding mismatch emits
+       `[:attesto, :token, :sender_constraint_mismatch]`. Checking it earlier
+       let any sender-bound token from this issuer - not one this resource
+       would accept - raise that event by being presented under another key.
+       A token failing both therefore reports `:invalid_audience`, not the
+       binding error.
+
   ## Options
 
     * `:now` - clock override.
@@ -308,8 +317,11 @@ defmodule Attesto.Token do
       This is intended for authorization-server operations such as RFC 7662
       introspection that recognize multiple RFC 8707 resource audiences. The
       resolver receives claims only after signature, exact issuer, temporal,
-      required-claim, principal, purpose, and confirmation checks succeed; the
-      `aud` claim is syntactically valid but has not yet been authorized. Use
+      required-claim, principal, purpose, and confirmation-SHAPE checks
+      succeed; the `aud` claim is syntactically valid but has not yet been
+      authorized, and the sender BINDING has not yet been checked, so a
+      resolver may see a token whose proof of possession later proves wrong.
+      Use
       those claims only to select audience policy. Do not derive trust from
       `aud` itself or perform irreversible work in the resolver. A resolver
       failure or malformed return fails closed. This option never disables

--- a/lib/attesto/token.ex
+++ b/lib/attesto/token.ex
@@ -283,19 +283,21 @@ defmodule Attesto.Token do
     5. **Temporal.** `exp` is strictly greater than `now` (no skew
        leeway). If `nbf` is present it MUST be an integer no later than
        `now` (RFC 7519 §4.1.5; a small clock-skew tolerance applies), else
-       `:not_yet_valid`. An `iat` meaningfully in the future is also
        `:not_yet_valid`.
     6. **Required claims** are present and well-typed: `sub`/`jti`
        non-empty strings, `scope` a string, `iat` a non-negative integer,
-       and both the principal-kind claim and `typ` present.
-    7. **Principal.** The principal-kind claim names a configured kind AND
+       and both the principal-kind claim and `typ` present. This runs BEFORE
+       the future-`iat` check below, so a token that is both malformed and
+       future-dated reports `:invalid_claims`.
+    7. **`iat` not meaningfully in the future**, else `:not_yet_valid`.
+    8. **Principal.** The principal-kind claim names a configured kind AND
        `sub` begins with that kind's `sub_prefix`; otherwise
        `:invalid_principal`.
-    8. **Per-kind claims.** The kind's `required_claims` are all present
+    9. **Per-kind claims.** The kind's `required_claims` are all present
        with the right shape; otherwise `:invalid_claims`.
-    9. **`typ`** is a known value AND equals the expected purpose
+   10. **`typ`** is a known value AND equals the expected purpose
        (`:expected_typ`, default `"access"`).
-   10. **Binding.** A DPoP-bound token requires a matching `:dpop_jkt`; an
+   11. **Binding.** A DPoP-bound token requires a matching `:dpop_jkt`; an
        mTLS-bound token a matching `:mtls_cert_thumbprint`; an unbound
        token requires neither. The cross-scheme option MUST be absent.
        See the error list for the precise outcomes.

--- a/lib/attesto/token.ex
+++ b/lib/attesto/token.ex
@@ -343,8 +343,19 @@ defmodule Attesto.Token do
          {:ok, kind} <- check_principal(config, claims),
          :ok <- check_principal_identity_claims(kind, claims),
          :ok <- check_typ(claims, opts),
-         :ok <- maybe_check_confirmation_binding(claims, opts),
-         :ok <- check_deferred_audience(claims, opts) do
+         # Audience before binding, deliberately. `maybe_check_confirmation_binding/2`
+         # emits `[:attesto, :token, :sender_constraint_mismatch]`, an event
+         # documented as evidence that a token has left its holder. Evaluating
+         # it first meant any sender-bound token from this issuer - not one for
+         # this resource - could be presented here under a second DPoP key to
+         # raise that alarm. Nothing claims the proof's `jti` on a failed
+         # verification either, so the same proof could be replayed for its
+         # whole freshness window, making the alarm arbitrarily cheap to ring.
+         #
+         # Deciding "is this token even for me" first means a token this
+         # resource would refuse anyway never reaches the check that reports.
+         :ok <- check_deferred_audience(claims, opts),
+         :ok <- maybe_check_confirmation_binding(claims, opts) do
       {:ok, claims}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.5.0"
+  @version "1.6.0"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 
@@ -143,6 +143,7 @@ defmodule Attesto.MixProject do
         Scopes: [Attesto.Scope],
         Metadata: [Attesto.JWKS, Attesto.Discovery],
         Keys: [Attesto.Keystore, Static, Attesto.Key],
+        Observability: [Attesto.Telemetry],
         Shared: [
           Attesto.Thumbprint,
           Attesto.SecureCompare,

--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,12 @@ defmodule Attesto.MixProject do
   defp deps do
     [
       {:jose, ">= 1.11.12 and < 2.0.0"},
+      # `Attesto.Telemetry` emits security-relevant refusals (refresh-token
+      # reuse, DPoP replay, sender-constraint mismatch) so a host can alert on
+      # them without wrapping every call site. A hard dependency rather than an
+      # optional one: a signal a host has to opt into compiling is a signal
+      # nobody receives, and the package is dependency-free and ~30KB.
+      {:telemetry, "~> 1.0"},
       # Optional: the Attesto.Plug.* integration layer. Hosts that use the
       # plugs already have Plug; the core library does not require it.
       {:plug, "~> 1.16.6 or ~> 1.17.4 or ~> 1.18.5 or ~> 1.19.5 or >= 1.20.3 and < 2.0.0", optional: true},

--- a/test/attesto/concurrency_swarm_test.exs
+++ b/test/attesto/concurrency_swarm_test.exs
@@ -75,7 +75,8 @@ defmodule Attesto.ConcurrencySwarmTest do
       # a loser whose read landed after a concurrent revoke deleted the row
       # (:invalid_grant). All three are safe.
       assert Enum.all?(results, fn r ->
-               match?({:ok, _}, r) or r in [{:error, :reuse_detected}, {:error, :invalid_grant}]
+               match?({:ok, _}, r) or
+                 r in [{:error, :reuse_detected}, {:error, :grant_revoked}, {:error, :invalid_grant}]
              end),
              "results must be {:ok,_}, :reuse_detected, or :invalid_grant; got #{inspect(results)}"
 

--- a/test/attesto/dpop_test.exs
+++ b/test/attesto/dpop_test.exs
@@ -846,7 +846,7 @@ defmodule Attesto.DPoP.ReplayCacheIntegrationTest do
   @http_uri "https://api.example.com/oauth/token"
 
   setup do
-    start_supervised!({ReplayCache, ttl_seconds: 60, multi_node_acknowledged?: true})
+    start_supervised!({ReplayCache, multi_node_acknowledged?: true})
     :ok
   end
 

--- a/test/attesto/grants_concurrency_test.exs
+++ b/test/attesto/grants_concurrency_test.exs
@@ -86,8 +86,24 @@ defmodule Attesto.GrantsConcurrencyTest do
              end)
 
       # Whichever way the race resolved, the family must not be left in a
-      # forked state: a fresh rotation of the original token now fails.
-      refute match?({:ok, _}, RefreshToken.rotate(RefreshStore.ETS, t0))
+      # FORKED state. That is the invariant; "the next rotation fails" is not,
+      # and asserting it made this test load-dependent.
+      #
+      # Within `:rotation_grace_seconds` (10s by default) a matching retry of
+      # an already-consumed parent is documented to return the SAME successor,
+      # so whether this call fails depends on which way the racers resolved: if
+      # a loser tripped reuse detection the family is revoked and the row is
+      # gone (`:invalid_grant`), but if every loser landed on the idempotent
+      # path there is nothing to revoke and the original successor is returned
+      # again. Both are correct. Only a NEW successor would be a fork.
+      case RefreshToken.rotate(RefreshStore.ETS, t0) do
+        {:ok, %{token: token}} ->
+          assert token in successors,
+                 "a post-race rotation minted a successor no racer saw, forking the family"
+
+        {:error, reason} ->
+          assert reason in [:reuse_detected, :invalid_grant]
+      end
     end
   end
 end

--- a/test/attesto/grants_concurrency_test.exs
+++ b/test/attesto/grants_concurrency_test.exs
@@ -9,6 +9,7 @@ defmodule Attesto.GrantsConcurrencyTest do
 
   alias Attesto.AuthorizationCode
   alias Attesto.CodeStore
+  alias Attesto.GrantsConcurrencyTest.RecordingStore
   alias Attesto.PKCE
   alias Attesto.RefreshStore
   alias Attesto.RefreshToken
@@ -105,5 +106,115 @@ defmodule Attesto.GrantsConcurrencyTest do
           assert reason in [:reuse_detected, :invalid_grant]
       end
     end
+
+    # The test above can only see successors that were RETURNED to a caller. A
+    # child written to storage and then not handed back is invisible to it, and
+    # a child sitting in the store is a usable credential whether or not anyone
+    # received it. This one watches the store instead.
+    #
+    # What it can and cannot catch, stated plainly because the difference is
+    # not obvious:
+    #
+    #   * It CAN catch a successor that reaches storage without reaching a
+    #     caller. Today that is unreachable - `rotate/3` returns `{:ok, _}`
+    #     unconditionally once `issue/3` has inserted, and the
+    #     `remember_successor` result is deliberately discarded - so this is a
+    #     guard against a future failure point being introduced between the
+    #     insert and the return, not a live defect.
+    #
+    #   * It CANNOT catch a non-atomic `consume`. That was worth trying: with
+    #     `{:reuse, _}` rewired to `{:ok, _}` so several racers claim the same
+    #     parent, the run produced ZERO successors, not two - the extra
+    #     claimants revoke the family, and the winner's own insert is then
+    #     refused. A broken claim degenerates into total failure rather than a
+    #     fork, so no assertion about forks can detect it. The atomicity of
+    #     `consume` is the store's contract, tested where the stores are.
+    #
+    # The vacuity guard below matters for the same reason: without it, "no
+    # successors were persisted" would satisfy a fork assertion perfectly.
+    test "no second successor is persisted, even one no caller received" do
+      RecordingStore.reset()
+
+      {:ok, %{token: t0}} =
+        RefreshToken.issue(RecordingStore, %{subject: "usr_42", scope: ["documents.read"]})
+
+      results = race(fn -> RefreshToken.rotate(RecordingStore, t0) end)
+
+      # Generation 0 is the parent from `issue/3`; anything above it is a
+      # successor that actually landed in storage.
+      persisted =
+        RecordingStore.persisted()
+        |> Enum.filter(&(&1.generation >= 1))
+        |> Enum.map(& &1.token_hash)
+        |> Enum.uniq()
+
+      assert length(persisted) <= 1,
+             "the race persisted #{length(persisted)} distinct successors; one parent may father at most one child"
+
+      # Guard against a vacuous pass: an empty store satisfies "at most one
+      # successor" perfectly, so require evidence the race reached the claim at
+      # all. Zero persisted successors is itself legitimate - a loser can
+      # revoke the family in the window between the winner's `consume` and its
+      # `insert`, so the winner's child is refused - which is why this asserts
+      # that the claim was REACHED rather than that a child exists.
+      assert Enum.any?(results, &(match?({:ok, _}, &1) or &1 == {:error, :reuse_detected})),
+             "no racer won the claim or tripped reuse detection, so nothing was ruled out " <>
+               "(outcomes: #{inspect(Enum.frequencies_by(results, fn
+                 {:ok, _} -> :ok
+                 {:error, r} -> r
+               end))})"
+
+      # Every outcome must be terminal-and-safe: a successor, or a refusal.
+      # Nothing may report success without appearing in the store.
+      for {:ok, %{token: token}} <- results do
+        assert Attesto.Secret.hash(token) in persisted,
+               "a racer was handed a successor that is not in the store"
+      end
+    end
+  end
+
+  # Wraps the ETS reference store and records every successor insert that
+  # actually landed, so a test can assert over what STORAGE holds rather than
+  # only over what callers were handed back. Records after the delegate
+  # returns `:ok`, so an insert the store refused (`:family_revoked`) is not
+  # counted as persisted.
+  defmodule RecordingStore do
+    @moduledoc false
+    @behaviour Attesto.RefreshStore
+
+    @table :grants_concurrency_insert_log
+
+    def reset do
+      if :ets.whereis(@table) != :undefined, do: :ets.delete(@table)
+      :ets.new(@table, [:duplicate_bag, :public, :named_table])
+      :ok
+    end
+
+    def persisted, do: Enum.map(:ets.tab2list(@table), fn {:persisted, entry} -> entry end)
+
+    @impl true
+    def insert(entry) do
+      case RefreshStore.ETS.insert(entry) do
+        :ok ->
+          :ets.insert(@table, {:persisted, entry})
+          :ok
+
+        other ->
+          other
+      end
+    end
+
+    @impl true
+    def get(token_hash), do: RefreshStore.ETS.get(token_hash)
+
+    @impl true
+    def consume(token_hash, opts), do: RefreshStore.ETS.consume(token_hash, opts)
+
+    @impl true
+    def remember_successor(token_hash, successor, opts),
+      do: RefreshStore.ETS.remember_successor(token_hash, successor, opts)
+
+    @impl true
+    def revoke_family(family_id), do: RefreshStore.ETS.revoke_family(family_id)
   end
 end

--- a/test/attesto/grants_concurrency_test.exs
+++ b/test/attesto/grants_concurrency_test.exs
@@ -83,7 +83,8 @@ defmodule Attesto.GrantsConcurrencyTest do
              "at most one distinct successor may be minted; got #{length(successors)}"
 
       assert Enum.all?(results, fn r ->
-               match?({:ok, _}, r) or r == {:error, :reuse_detected} or r == {:error, :invalid_grant}
+               match?({:ok, _}, r) or
+                 r in [{:error, :reuse_detected}, {:error, :grant_revoked}, {:error, :invalid_grant}]
              end)
 
       # Whichever way the race resolved, the family must not be left in a
@@ -103,7 +104,7 @@ defmodule Attesto.GrantsConcurrencyTest do
                  "a post-race rotation minted a successor no racer saw, forking the family"
 
         {:error, reason} ->
-          assert reason in [:reuse_detected, :invalid_grant]
+          assert reason in [:reuse_detected, :grant_revoked, :invalid_grant]
       end
     end
 
@@ -159,7 +160,7 @@ defmodule Attesto.GrantsConcurrencyTest do
       # revoke the family in the window between the winner's `consume` and its
       # `insert`, so the winner's child is refused - which is why this asserts
       # that the claim was REACHED rather than that a child exists.
-      assert Enum.any?(results, &(match?({:ok, _}, &1) or &1 == {:error, :reuse_detected})),
+      assert Enum.any?(results, &(match?({:ok, _}, &1) or &1 in [{:error, :reuse_detected}, {:error, :grant_revoked}])),
              "no racer won the claim or tripped reuse detection, so nothing was ruled out " <>
                "(outcomes: #{inspect(Enum.frequencies_by(results, fn
                  {:ok, _} -> :ok
@@ -185,7 +186,8 @@ defmodule Attesto.GrantsConcurrencyTest do
       # Every outcome must be terminal-and-safe: a successor, or one of the
       # refusals that leaves no successor behind.
       assert Enum.all?(results, fn r ->
-               match?({:ok, _}, r) or r in [{:error, :reuse_detected}, {:error, :invalid_grant}]
+               match?({:ok, _}, r) or
+                 r in [{:error, :reuse_detected}, {:error, :grant_revoked}, {:error, :invalid_grant}]
              end)
     end
   end

--- a/test/attesto/grants_concurrency_test.exs
+++ b/test/attesto/grants_concurrency_test.exs
@@ -116,19 +116,21 @@ defmodule Attesto.GrantsConcurrencyTest do
     # not obvious:
     #
     #   * It CAN catch a successor that reaches storage without reaching a
-    #     caller. Today that is unreachable - `rotate/3` returns `{:ok, _}`
-    #     unconditionally once `issue/3` has inserted, and the
-    #     `remember_successor` result is deliberately discarded - so this is a
-    #     guard against a future failure point being introduced between the
-    #     insert and the return, not a live defect.
+    #     caller. `rotate/3` returns `{:ok, _}` unconditionally once `issue/3`
+    #     has inserted and the `remember_successor/3` RESULT is discarded, so a
+    #     store that merely returns an error there cannot strand a child - but
+    #     one that RAISES leaves the child persisted while the caller gets an
+    #     exception, and a host writes those stores.
     #
-    #   * It CANNOT catch a non-atomic `consume`. That was worth trying: with
-    #     `{:reuse, _}` rewired to `{:ok, _}` so several racers claim the same
-    #     parent, the run produced ZERO successors, not two - the extra
-    #     claimants revoke the family, and the winner's own insert is then
-    #     refused. A broken claim degenerates into total failure rather than a
-    #     fork, so no assertion about forks can detect it. The atomicity of
-    #     `consume` is the store's contract, tested where the stores are.
+    #   * It does NOT prove `consume/2` is atomic, though it can catch some
+    #     non-atomic implementations. A store whose `consume` only reads and
+    #     reports success produces 25 distinct persisted successors, which the
+    #     fork assertion rejects. A different break does not: rewiring
+    #     `{:reuse, _}` to `{:ok, _}` yields ZERO successors instead of two,
+    #     because the extra claimants revoke the family and the winner's own
+    #     insert is then refused. Passing here means no fork was observed in
+    #     this run, not that the claim is atomic - that is the store's
+    #     contract, tested where the stores are.
     #
     # The vacuity guard below matters for the same reason: without it, "no
     # successors were persisted" would satisfy a fork assertion perfectly.
@@ -164,12 +166,27 @@ defmodule Attesto.GrantsConcurrencyTest do
                  {:error, r} -> r
                end))})"
 
-      # Every outcome must be terminal-and-safe: a successor, or a refusal.
-      # Nothing may report success without appearing in the store.
-      for {:ok, %{token: token}} <- results do
-        assert Attesto.Secret.hash(token) in persisted,
-               "a racer was handed a successor that is not in the store"
+      # Both inclusions, because either alone is satisfiable while the other
+      # fails. Every successor handed out must be in the store (nobody holds a
+      # credential the store does not know), AND every successor in the store
+      # must have been handed out (nothing is stranded there unclaimed, which
+      # is the case a `remember_successor/3` that raises would produce).
+      returned = for({:ok, %{token: token}} <- results, do: Attesto.Secret.hash(token)) |> Enum.uniq()
+
+      for hash <- returned do
+        assert hash in persisted, "a racer was handed a successor that is not in the store"
       end
+
+      for hash <- persisted do
+        assert hash in returned,
+               "a successor is in the store that no racer received; a stranded child is still a usable credential"
+      end
+
+      # Every outcome must be terminal-and-safe: a successor, or one of the
+      # refusals that leaves no successor behind.
+      assert Enum.all?(results, fn r ->
+               match?({:ok, _}, r) or r in [{:error, :reuse_detected}, {:error, :invalid_grant}]
+             end)
     end
   end
 

--- a/test/attesto/plug/authenticate_test.exs
+++ b/test/attesto/plug/authenticate_test.exs
@@ -522,6 +522,53 @@ defmodule Attesto.Plug.AuthenticateTest do
 
     # The property that must not regress: deferring WHEN the claim happens
     # does not weaken WHETHER a replay is refused.
+    # The plug no longer routes through `DPoP.check_replay/2` (it defers the
+    # claim), so the core's emission point is never reached on this path. The
+    # advertised event has to come from the plug or it does not come at all.
+    test "a replay refused by the plug still emits the advertised event", %{config: config} do
+      handler = "plug-replay-telemetry"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler,
+        [:attesto, :dpop, :replay_detected],
+        fn _e, _m, meta, _c -> send(test_pid, {:replay_event, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler) end)
+
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      jkt = JOSE.JWK.thumbprint(jwk)
+      {:ok, %{access_token: token}} = Token.mint(config, client_principal(), dpop_jkt: jkt)
+      {proof, ^jkt} = Factory.dpop_proof(jwk: jwk, htm: "GET", htu: @uri, ath: DPoP.compute_ath(token))
+
+      conn =
+        [{"authorization", "DPoP " <> token}, {"dpop", proof}]
+        |> request()
+        |> Authenticate.call(Authenticate.init(config: config, replay_check: fn _jti, _ttl -> {:error, :replay} end))
+
+      assert conn.status == 401
+      assert_received {:replay_event, meta}
+      assert is_binary(meta.jti)
+    end
+
+    # A replay store that is down must not be reported as a bad client.
+    test "an unexpected :replay_check return raises rather than becoming a 401", %{config: config} do
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      jkt = JOSE.JWK.thumbprint(jwk)
+      {:ok, %{access_token: token}} = Token.mint(config, client_principal(), dpop_jkt: jkt)
+      {proof, ^jkt} = Factory.dpop_proof(jwk: jwk, htm: "GET", htu: @uri, ath: DPoP.compute_ath(token))
+
+      opts = Authenticate.init(config: config, replay_check: fn _jti, _ttl -> {:error, :unavailable} end)
+
+      assert_raise ArgumentError, ~r/must return :ok or \{:error, :replay\}/, fn ->
+        [{"authorization", "DPoP " <> token}, {"dpop", proof}]
+        |> request()
+        |> Authenticate.call(opts)
+      end
+    end
+
     test "a replayed jti on an otherwise-valid request is still refused", %{config: config} do
       jwk = JOSE.JWK.generate_key({:ec, "P-256"})
       jkt = JOSE.JWK.thumbprint(jwk)

--- a/test/attesto/plug/authenticate_test.exs
+++ b/test/attesto/plug/authenticate_test.exs
@@ -454,6 +454,98 @@ defmodule Attesto.Plug.AuthenticateTest do
       assert conn.assigns.attesto_claims["sub"] == "oc_abc123"
     end
 
+    # RFC 9449 §11.1 requires single-use enforcement of the proof `jti`, and
+    # the default check is check-AND-record. Running it during proof
+    # validation would mean an unauthenticated caller writes a row on every
+    # request: a proof is signed by a key the caller generated, so anyone can
+    # mint a valid one and pair it with any string in the Authorization
+    # header. The claim therefore waits until the access token has verified.
+    test "a valid proof with an unverifiable token never claims its jti", %{config: config} do
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      jkt = JOSE.JWK.thumbprint(jwk)
+
+      # A syntactically fine proof, correctly bound to the presented string -
+      # which is not a token this server issued.
+      garbage = "not.a.token"
+      {proof, ^jkt} = Factory.dpop_proof(jwk: jwk, htm: "GET", htu: @uri, ath: DPoP.compute_ath(garbage))
+
+      test_pid = self()
+
+      conn =
+        [{"authorization", "DPoP " <> garbage}, {"dpop", proof}]
+        |> request()
+        |> Authenticate.call(
+          Authenticate.init(
+            config: config,
+            replay_check: fn jti, _ttl ->
+              send(test_pid, {:claimed, jti})
+              :ok
+            end
+          )
+        )
+
+      assert conn.status == 401
+      assert JSON.decode!(conn.resp_body)["error"] == "invalid_token"
+
+      refute_received {:claimed, _jti},
+                      "an unauthenticated request must not write to the replay store"
+    end
+
+    test "a valid request does claim its jti", %{config: config} do
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      jkt = JOSE.JWK.thumbprint(jwk)
+
+      {:ok, %{access_token: token}} = Token.mint(config, client_principal(), dpop_jkt: jkt)
+      ath = DPoP.compute_ath(token)
+      {proof, ^jkt} = Factory.dpop_proof(jwk: jwk, htm: "GET", htu: @uri, ath: ath)
+
+      test_pid = self()
+
+      conn =
+        [{"authorization", "DPoP " <> token}, {"dpop", proof}]
+        |> request()
+        |> Authenticate.call(
+          Authenticate.init(
+            config: config,
+            replay_check: fn jti, ttl ->
+              send(test_pid, {:claimed, jti, ttl})
+              :ok
+            end
+          )
+        )
+
+      refute conn.halted
+      assert_received {:claimed, jti, ttl}
+      assert is_binary(jti)
+      assert is_integer(ttl) and ttl > 0, "the claim must carry the verifier's own acceptance window"
+    end
+
+    # The property that must not regress: deferring WHEN the claim happens
+    # does not weaken WHETHER a replay is refused.
+    test "a replayed jti on an otherwise-valid request is still refused", %{config: config} do
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      jkt = JOSE.JWK.thumbprint(jwk)
+
+      {:ok, %{access_token: token}} = Token.mint(config, client_principal(), dpop_jkt: jkt)
+      ath = DPoP.compute_ath(token)
+      {proof, ^jkt} = Factory.dpop_proof(jwk: jwk, htm: "GET", htu: @uri, ath: ath)
+
+      opts =
+        Authenticate.init(
+          config: config,
+          replay_check: fn _jti, _ttl -> {:error, :replay} end
+        )
+
+      conn =
+        [{"authorization", "DPoP " <> token}, {"dpop", proof}]
+        |> request()
+        |> Authenticate.call(opts)
+
+      assert conn.status == 401
+      assert JSON.decode!(conn.resp_body)["error"] == "invalid_dpop_proof"
+      assert JSON.decode!(conn.resp_body)["error_description"] == "replay"
+    end
+
     test "a proof bound to the wrong htu is 401 invalid_dpop_proof", %{config: config} do
       jwk = JOSE.JWK.generate_key({:ec, "P-256"})
       jkt = JOSE.JWK.thumbprint(jwk)

--- a/test/attesto/secure_compare_test.exs
+++ b/test/attesto/secure_compare_test.exs
@@ -23,4 +23,54 @@ defmodule Attesto.SecureCompareTest do
     refute SecureCompare.equal?(:abc, "abc")
     refute SecureCompare.equal?(123, 123)
   end
+
+  describe "length independence" do
+    # A caveat about what these tests can and cannot do.
+    #
+    # The property at stake is a TIMING one: the comparison must not
+    # short-circuit on a length mismatch, because the time to answer would
+    # then separate "wrong length" from "right length, wrong bytes". No
+    # assertion below detects that. All of them pass against the
+    # short-circuiting implementation this replaced, which was verified by
+    # reverting it and re-running. A wall-clock assertion would be the only
+    # test that fails on the old code, and a timing assertion on a shared CI
+    # runner is a flake generator, not a guard.
+    #
+    # So these pin the BEHAVIOUR the fix must preserve, not the fix itself:
+    # that hashing both operands still answers exactly "are these identical",
+    # including the cases a careless implementation gets wrong - a prefix
+    # compared against the value it prefixes, one side hashed but not the
+    # other, an empty operand. The timing property is held by construction
+    # (both operands become 32-byte digests before comparison) and by the
+    # moduledoc that explains why, which is where a future change would have
+    # to argue with it.
+    test "wildly different lengths still compare false without raising" do
+      refute SecureCompare.equal?("a", String.duplicate("a", 100_000))
+      refute SecureCompare.equal?(String.duplicate("a", 100_000), "a")
+      refute SecureCompare.equal?("", "a")
+      refute SecureCompare.equal?("a", "")
+    end
+
+    test "equality holds for variable-length values, not only fixed-size digests" do
+      secret = "s_" <> String.duplicate("x", 137)
+
+      assert SecureCompare.equal?(secret, secret)
+      refute SecureCompare.equal?(secret, secret <> "y")
+      refute SecureCompare.equal?(secret, String.replace_suffix(secret, "x", "y"))
+    end
+
+    test "a prefix is not equal to the value it prefixes" do
+      # The classic short-circuit bug: comparing only up to the shorter length.
+      refute SecureCompare.equal?("abc", "abcdef")
+      refute SecureCompare.equal?("abcdef", "abc")
+    end
+
+    # `:crypto.hash_equals/2` raises on unequal sizes, so the implementation
+    # has to guarantee equal-size operands itself. Pin that it never escapes.
+    test "never raises, whatever the sizes" do
+      for {a, b} <- [{"", "x"}, {"x", ""}, {"ab", "abcdefghij"}, {String.duplicate("q", 4097), "q"}] do
+        assert is_boolean(SecureCompare.equal?(a, b))
+      end
+    end
+  end
 end

--- a/test/attesto/telemetry_test.exs
+++ b/test/attesto/telemetry_test.exs
@@ -81,6 +81,79 @@ defmodule Attesto.TelemetryTest do
       refute_received {:telemetry, _event, _measurements, _metadata}
     end
 
+    # Three paths conclude "presented twice": the initial read finds an
+    # already-consumed token, the atomic `consume` reports `{:reuse, _}`
+    # against a concurrent rotation, or our own claim wins and then finds the
+    # family revoked underneath it. The first is a lone late retry; the other
+    # two are a live race - the shape an attacker racing the legitimate client
+    # actually produces, and the two that were silent.
+    #
+    # A real race cannot test this: whether any racer reaches the concurrent
+    # branch is timing-dependent, and an emission from the initial-read path
+    # looks identical from outside. These stores force each branch instead.
+    defmodule ReuseOnConsumeStore do
+      @moduledoc false
+      @behaviour Attesto.RefreshStore
+
+      @entry %{
+        token_hash: "hash",
+        family_id: "fam_concurrent",
+        generation: 0,
+        data: %{subject: "usr_concurrent", client_id: "oc_racer", scope: [], resource: [], claims: %{}, dpop_jkt: nil},
+        expires_at: 4_102_444_800,
+        consumed: false,
+        consumed_at: nil,
+        successor: nil
+      }
+
+      def entry, do: @entry
+
+      @impl true
+      def get(_hash), do: {:ok, @entry}
+      @impl true
+      def consume(_hash, _opts), do: {:reuse, @entry}
+      @impl true
+      def revoke_family(_family_id), do: :ok
+      @impl true
+      def insert(_entry), do: :ok
+      @impl true
+      def remember_successor(_hash, _successor, _opts), do: :ok
+    end
+
+    defmodule FamilyRevokedStore do
+      @moduledoc false
+      @behaviour Attesto.RefreshStore
+
+      @entry ReuseOnConsumeStore.entry()
+
+      @impl true
+      def get(_hash), do: {:ok, @entry}
+      @impl true
+      def consume(_hash, _opts), do: {:ok, @entry}
+      @impl true
+      def revoke_family(_family_id), do: :ok
+      @impl true
+      def insert(_entry), do: {:error, :family_revoked}
+      @impl true
+      def remember_successor(_hash, _successor, _opts), do: :ok
+    end
+
+    test "a concurrent claim losing to `consume` emits" do
+      assert {:error, :reuse_detected} = RefreshToken.rotate(ReuseOnConsumeStore, "presented", client_id: "oc_racer")
+
+      assert_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], _, metadata}
+      assert metadata.family_id == "fam_concurrent"
+      assert metadata.subject == "usr_concurrent"
+      assert metadata.client_id == "oc_racer"
+    end
+
+    test "winning the claim and then finding the family revoked emits" do
+      assert {:error, :reuse_detected} = RefreshToken.rotate(FamilyRevokedStore, "presented", client_id: "oc_racer")
+
+      assert_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], _, metadata}
+      assert metadata.family_id == "fam_concurrent"
+    end
+
     test "metadata carries no credential material" do
       {:ok, %{token: t0}} = RefreshToken.issue(RefreshStore.ETS, %{subject: "usr_79"})
       {:ok, %{token: successor}} = RefreshToken.rotate(RefreshStore.ETS, t0)

--- a/test/attesto/telemetry_test.exs
+++ b/test/attesto/telemetry_test.exs
@@ -147,11 +147,16 @@ defmodule Attesto.TelemetryTest do
       assert metadata.client_id == "oc_racer"
     end
 
-    test "winning the claim and then finding the family revoked emits" do
+    # This double reproduces the RETURN value of a revoked family but not its
+    # cause, and the cause is the whole question: `revoke_family/1` is also what
+    # an ordinary RFC 7009 revocation or a logout calls, so a family can be
+    # revoked mid-rotation by a token presented exactly once. The library cannot
+    # tell the two apart from this branch, so it denies without accusing.
+    test "winning the claim and then finding the family revoked denies WITHOUT alleging reuse" do
       assert {:error, :reuse_detected} = RefreshToken.rotate(FamilyRevokedStore, "presented", client_id: "oc_racer")
 
-      assert_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], _, metadata}
-      assert metadata.family_id == "fam_concurrent"
+      refute_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], _, _},
+                      "a concurrent logout must not page someone about a stolen credential"
     end
 
     test "metadata carries no credential material" do
@@ -267,8 +272,11 @@ defmodule Attesto.TelemetryTest do
     end
   end
 
-  # A handler that raises is detached by :telemetry itself; what must not
-  # happen is the refusal turning into a crash for the caller.
+  # `:telemetry.execute/3` catches a raising handler, detaches it, and logs, so
+  # the refusal is never taken down by a bad handler. Attesto adds no catch of
+  # its own: one would also swallow a dispatcher failure, and silently losing an
+  # event whose purpose is to say a credential may be stolen is worse than
+  # failing loudly - a missing event leaves nothing to notice later.
   describe "a failing handler does not change the outcome" do
     test "reuse detection still returns :reuse_detected" do
       :telemetry.attach(

--- a/test/attesto/telemetry_test.exs
+++ b/test/attesto/telemetry_test.exs
@@ -1,0 +1,194 @@
+defmodule Attesto.TelemetryTest do
+  @moduledoc false
+  # The event names and metadata keys asserted here are public API: a host
+  # attaches to them and routes them to a pager or a SIEM. Renaming one, or
+  # dropping a documented key, breaks that host silently at runtime - there is
+  # no compile-time link between an emitter and a handler. These tests are the
+  # link.
+  use ExUnit.Case, async: false
+
+  alias Attesto.RefreshStore
+  alias Attesto.RefreshToken
+  alias Attesto.Telemetry
+  alias Attesto.Test.Factory
+  alias Attesto.Token
+
+  setup context do
+    handler = "attesto-telemetry-test-#{inspect(context.test)}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler,
+        Telemetry.events(),
+        fn event, measurements, metadata, _cfg ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    start_supervised!(RefreshStore.ETS)
+    :ok
+  end
+
+  describe "events/0" do
+    test "lists every event the library emits, for attach_many/4" do
+      assert Telemetry.events() == [
+               [:attesto, :refresh_token, :reuse_detected],
+               [:attesto, :dpop, :replay_detected],
+               [:attesto, :token, :sender_constraint_mismatch]
+             ]
+    end
+  end
+
+  describe "[:attesto, :refresh_token, :reuse_detected]" do
+    test "fires when a rotated token is presented again, carrying the revoked family" do
+      {:ok, %{token: t0}} =
+        RefreshToken.issue(RefreshStore.ETS, %{
+          subject: "usr_77",
+          client_id: "oc_client",
+          scope: ["documents.read"]
+        })
+
+      # Rotation is fail-closed on the client binding: a token issued with a
+      # `client_id` must present a matching one.
+      {:ok, _successor} = RefreshToken.rotate(RefreshStore.ETS, t0, client_id: "oc_client")
+
+      # Outside the idempotency window the reuse is a captured-token signal.
+      assert {:error, :reuse_detected} =
+               RefreshToken.rotate(RefreshStore.ETS, t0, client_id: "oc_client", now: future())
+
+      assert_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], measurements, metadata}
+
+      assert is_integer(measurements.system_time)
+      assert is_binary(metadata.family_id)
+      assert metadata.client_id == "oc_client"
+      assert metadata.subject == "usr_77"
+    end
+
+    test "an ordinary successful rotation emits nothing" do
+      {:ok, %{token: t0}} = RefreshToken.issue(RefreshStore.ETS, %{subject: "usr_78"})
+      {:ok, _} = RefreshToken.rotate(RefreshStore.ETS, t0)
+
+      refute_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], _, _}
+    end
+
+    # Routine refusals must not be events, or the signal above drowns.
+    test "an unknown token emits nothing" do
+      assert {:error, :invalid_grant} = RefreshToken.rotate(RefreshStore.ETS, "no-such-token")
+
+      refute_received {:telemetry, _event, _measurements, _metadata}
+    end
+
+    test "metadata carries no credential material" do
+      {:ok, %{token: t0}} = RefreshToken.issue(RefreshStore.ETS, %{subject: "usr_79"})
+      {:ok, %{token: successor}} = RefreshToken.rotate(RefreshStore.ETS, t0)
+      {:error, :reuse_detected} = RefreshToken.rotate(RefreshStore.ETS, t0, now: future())
+
+      assert_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], _, metadata}
+
+      encoded = inspect(metadata)
+      refute encoded =~ t0, "the presented refresh token must not appear in metadata"
+      refute encoded =~ successor, "the successor token must not appear in metadata"
+    end
+  end
+
+  describe "[:attesto, :dpop, :replay_detected]" do
+    test "fires when the replay check refuses a jti" do
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      {proof, _jkt} = Factory.dpop_proof(jwk: jwk, htm: "GET", htu: "https://api.example.com/x")
+
+      assert {:error, :replay} =
+               Attesto.DPoP.verify_proof(proof,
+                 http_method: "GET",
+                 http_uri: "https://api.example.com/x",
+                 replay_check: fn _jti, _ttl -> {:error, :replay} end
+               )
+
+      assert_received {:telemetry, [:attesto, :dpop, :replay_detected], measurements, metadata}
+      assert is_integer(measurements.system_time)
+      assert is_binary(metadata.jti)
+    end
+
+    test "a first-use proof emits nothing" do
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      {proof, _jkt} = Factory.dpop_proof(jwk: jwk, htm: "GET", htu: "https://api.example.com/x")
+
+      assert {:ok, _} =
+               Attesto.DPoP.verify_proof(proof,
+                 http_method: "GET",
+                 http_uri: "https://api.example.com/x",
+                 replay_check: fn _jti, _ttl -> :ok end
+               )
+
+      refute_received {:telemetry, [:attesto, :dpop, :replay_detected], _, _}
+    end
+  end
+
+  describe "[:attesto, :token, :sender_constraint_mismatch]" do
+    setup do
+      {:ok, config: Factory.config(Factory.rsa_pem())}
+    end
+
+    test "fires when a DPoP-bound token is presented under the wrong key", %{config: config} do
+      bound = JOSE.JWK.thumbprint(JOSE.JWK.generate_key({:ec, "P-256"}))
+      other = JOSE.JWK.thumbprint(JOSE.JWK.generate_key({:ec, "P-256"}))
+
+      {:ok, %{access_token: token}} =
+        Token.mint(config, principal(), dpop_jkt: bound)
+
+      assert {:error, :dpop_binding_mismatch} = Token.verify(config, token, dpop_jkt: other)
+
+      assert_received {:telemetry, [:attesto, :token, :sender_constraint_mismatch], _measurements, metadata}
+      assert metadata.binding == :dpop
+      assert metadata.reason == :dpop_binding_mismatch
+      assert metadata.client_id == "oc_abc"
+    end
+
+    test "an unbound token verified normally emits nothing", %{config: config} do
+      {:ok, %{access_token: token}} = Token.mint(config, principal())
+
+      assert {:ok, _claims} = Token.verify(config, token)
+
+      refute_received {:telemetry, [:attesto, :token, :sender_constraint_mismatch], _, _}
+    end
+
+    test "metadata carries no token material", %{config: config} do
+      bound = JOSE.JWK.thumbprint(JOSE.JWK.generate_key({:ec, "P-256"}))
+      other = JOSE.JWK.thumbprint(JOSE.JWK.generate_key({:ec, "P-256"}))
+
+      {:ok, %{access_token: token}} = Token.mint(config, principal(), dpop_jkt: bound)
+      {:error, :dpop_binding_mismatch} = Token.verify(config, token, dpop_jkt: other)
+
+      assert_received {:telemetry, [:attesto, :token, :sender_constraint_mismatch], _, metadata}
+      refute inspect(metadata) =~ token
+    end
+  end
+
+  # A handler that raises is detached by :telemetry itself; what must not
+  # happen is the refusal turning into a crash for the caller.
+  describe "a failing handler does not change the outcome" do
+    test "reuse detection still returns :reuse_detected" do
+      :telemetry.attach(
+        "attesto-telemetry-raiser",
+        [:attesto, :refresh_token, :reuse_detected],
+        fn _e, _m, _md, _c -> raise "handler blew up" end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach("attesto-telemetry-raiser") end)
+
+      {:ok, %{token: t0}} = RefreshToken.issue(RefreshStore.ETS, %{subject: "usr_80"})
+      {:ok, _} = RefreshToken.rotate(RefreshStore.ETS, t0)
+
+      assert {:error, :reuse_detected} = RefreshToken.rotate(RefreshStore.ETS, t0, now: future())
+    end
+  end
+
+  defp future, do: DateTime.add(DateTime.utc_now(), 3600, :second)
+
+  defp principal do
+    %{kind: "client", sub: "oc_abc", scopes: ["documents.read"], claims: %{"client_id" => "oc_abc"}}
+  end
+end

--- a/test/attesto/telemetry_test.exs
+++ b/test/attesto/telemetry_test.exs
@@ -219,6 +219,34 @@ defmodule Attesto.TelemetryTest do
       assert metadata.client_id == "oc_abc"
     end
 
+    # The event is documented as evidence a token has left its holder, so it
+    # must not be ringable by someone who merely holds ANY sender-bound token
+    # from this issuer. Presenting one under a second key at a resource whose
+    # audience policy would refuse it anyway must be refused on the audience,
+    # silently - otherwise the alarm is free to ring, and repeatedly, since a
+    # failed verification never claims the proof's `jti`.
+    test "a token this resource would refuse on audience does not ring the alarm", %{config: config} do
+      bound = JOSE.JWK.thumbprint(JOSE.JWK.generate_key({:ec, "P-256"}))
+      other = JOSE.JWK.thumbprint(JOSE.JWK.generate_key({:ec, "P-256"}))
+      elsewhere = "https://elsewhere.example/api"
+
+      {:ok, %{access_token: token}} =
+        Token.mint(config, principal(), dpop_jkt: bound, audience: elsewhere)
+
+      # This resource trusts a different audience, and is presented the token
+      # under the wrong key: both checks would fail.
+      assert {:error, reason} =
+               Token.verify(config, token,
+                 dpop_jkt: other,
+                 trusted_audiences: fn _claims -> ["https://this-resource.example/api"] end
+               )
+
+      assert reason == :invalid_audience,
+             "audience must be decided before the binding check that reports"
+
+      refute_received {:telemetry, [:attesto, :token, :sender_constraint_mismatch], _, _}
+    end
+
     test "an unbound token verified normally emits nothing", %{config: config} do
       {:ok, %{access_token: token}} = Token.mint(config, principal())
 

--- a/test/attesto/telemetry_test.exs
+++ b/test/attesto/telemetry_test.exs
@@ -153,7 +153,9 @@ defmodule Attesto.TelemetryTest do
     # revoked mid-rotation by a token presented exactly once. The library cannot
     # tell the two apart from this branch, so it denies without accusing.
     test "winning the claim and then finding the family revoked denies WITHOUT alleging reuse" do
-      assert {:error, :reuse_detected} = RefreshToken.rotate(FamilyRevokedStore, "presented", client_id: "oc_racer")
+      # `:grant_revoked`, not `:reuse_detected`: the return says what is known
+      # (the family is gone) rather than what is not (why).
+      assert {:error, :grant_revoked} = RefreshToken.rotate(FamilyRevokedStore, "presented", client_id: "oc_racer")
 
       refute_received {:telemetry, [:attesto, :refresh_token, :reuse_detected], _, _},
                       "a concurrent logout must not page someone about a stolen credential"

--- a/test/support/replay_cache_contract.ex
+++ b/test/support/replay_cache_contract.ex
@@ -38,8 +38,7 @@ defmodule Attesto.ReplayCacheContract do
   #       use Attesto.ReplayCacheContract,
   #         start: fn ->
   #           start_supervised!(
-  #             {Attesto.DPoP.ReplayCache,
-  #              ttl_seconds: 60, multi_node_acknowledged?: true}
+  #             {Attesto.DPoP.ReplayCache, multi_node_acknowledged?: true}
   #           )
   #         end,
   #         check: fn -> &Attesto.DPoP.ReplayCache.check_and_record/2 end


### PR DESCRIPTION
Release **1.6.0**. Four adversarial review rounds (`gpt-5.6-sol` at `xhigh`), 26 findings, all fixed.

## Security

**Claim a DPoP proof's `jti` only after the access token has verified.** `Attesto.Plug.Authenticate` ran `:replay_check` — a check-AND-record operation — two steps before `verify_token`, so an unauthenticated caller wrote a replay-store row on every request. A proof is signed by a key the caller generated, so anyone could mint one, pair it with any string in the `Authorization` header, and grow an unbounded ETS table for the cost of a signature.

RFC 9449 §11.1 is unchanged: the claim is still an atomic check-and-record made before the request is served.

**`SecureCompare.equal?/2` no longer short-circuits on length**, so it no longer separates "wrong length" from "right length, wrong bytes" — the distinction an attacker probes with. `Attesto.DPoP`'s `ath` comparison takes an arbitrary-length value straight from the proof and was the exposed caller.

**A rotation that finds its family revoked returns `:grant_revoked`, not `:reuse_detected`.** `Attesto.Revocation` calls the same `revoke_family/1`, so a user logging out mid-rotation was being reported as a stolen credential.

## Added

`Attesto.Telemetry` — three events for the refusals that are the shape a stolen credential makes: refresh-token reuse, DPoP replay, sender-constraint mismatch. Ordinary failures are deliberately not events. Documented as **indicators to correlate, not verdicts**: a client can ring the mismatch event at will with its own token, and a key rotation does it innocently. Handlers run synchronously with no timeout.

`Attesto.DPoP.verify_proof/2` now reports the `replay_ttl` it derived, so a caller deferring the claim uses that verification's own acceptance window.

## Verified

1625 tests (67 properties), credo, dialyzer, docs. **FAPI2 Security Profile conformance re-run against this branch on the live OP: 52 PASSED, 1 WARNING, 3 REVIEW, zero failures** — including `dpop-negative-tests` and `refresh-token`, the modules covering what changed.