### PR TITLE
DPoP replay-key namespacing + full-surface security sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every (required, granted) pair, so a large caller-supplied `scope` value - on
   which RFC 6749 §3.3 places no bound - was a denial-of-service lever: 500,000
   scope tokens took ~20 seconds. Classifying the granted set once and testing
-  each required scope against that index in O(1) drops the same input to ~40ms,
-  with an identical result (pinned by a property test against the naive form).
-  Surfaced by mining the class behind Keycloak CVE-2026-4634 against this code.
+  each required scope against that index in O(1) drops the same input to ~40ms.
+  For every proper-list input (the typespec's contract) the result is identical
+  to the naive form, pinned by a generated property test; an improper list now
+  raises rather than short-circuiting, a louder failure on a value the contract
+  already forbids. Surfaced by mining the class behind Keycloak CVE-2026-4634.
 
 ## [1.6.0] - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- `Attesto.Scope.grants_all?/3` is now linear in the requested-scope count.
+  It previously rescanned the granted set and re-split resource wildcards for
+  every (required, granted) pair, so a large caller-supplied `scope` value - on
+  which RFC 6749 §3.3 places no bound - was a denial-of-service lever: 500,000
+  scope tokens took ~20 seconds. Classifying the granted set once and testing
+  each required scope against that index in O(1) drops the same input to ~40ms,
+  with an identical result (pinned by a property test against the naive form).
+  Surfaced by mining the class behind Keycloak CVE-2026-4634 against this code.
+
 ## [1.6.0] - 2026-08-01
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- DPoP replay identities are now namespaced by the proof key. `jti` uniqueness
+  is only guaranteed per key (RFC 9449 §4.2), so recording the raw `jti` let two
+  keys sharing a `jti` collide in the replay store — a cross-client false replay
+  and a targeted DoS in which an authenticated attacker pre-burns a victim's
+  `jti` under the attacker's own key. `Attesto.DPoP.verify_proof/2` now returns
+  `replay_key`, a fixed-length digest of `jkt:jti`, and every replay path (the
+  plug, the token endpoint, PAR, device authorization) records THAT.
+
+  **Upgrade note:** the recorded identity's format changed (raw `jti` →
+  digest). During a rolling upgrade, old and new nodes write different formats
+  to a shared replay store, so a single proof could be accepted once on each
+  side within its acceptance window (`max_age + skew`, default ~120s). Drain old
+  nodes and wait out one proof lifetime, or briefly stop the world, to close
+  that window. A fresh deployment is unaffected.
+
+- A batch of fail-closed / correctness fixes found by a full-surface adversarial
+  sweep and two rounds of external review:
+  - `Attesto.DPoP` replay TTL now retains the `jti` one second past the
+    inclusive freshness boundary, closing a sub-second edge-of-life replay gap.
+  - `Attesto.IdentityAssertion` rejects a present non-integer `nbf` instead of
+    treating it as absent (`:invalid_claims`).
+  - `Attesto.RequestObject` parameter coercion is total: a request-object claim
+    that is a list with a non-string member is dropped rather than raising.
+  - CIBA signed authentication requests reject an authorization-endpoint
+    request object (`typ: oauth-authz-req+jwt`); `typ` comparison follows
+    RFC 7515 §4.1.9 for the `application/` prefix.
+  - `Attesto.JARM` reserved claims (`iss`/`aud`/`iat`/`exp`) can no longer be
+    shadowed by a caller's atom- or charlist-keyed duplicate.
+  - `Attesto.SessionState` rejects an OP browser-state secret under 32 bytes and
+    a `session_state` salt containing a space or `.`, and serializes the browser
+    origin closer to the WHATWG form (lowercase scheme/host, bracketed IPv6).
+
+### Changed
+
+- The `:replay_check` callback and `verify_proof/2`'s `replay_key` carry an
+  OPAQUE replay identity (a digest), not the raw `jti`; do not parse it. The
+  `[:attesto, :dpop, :replay_detected]` telemetry still carries the raw client
+  `jti` for correlation.
+
 - `Attesto.Scope.grants_all?/3` is now linear in the requested-scope count.
   It previously rescanned the granted set and re-split resource wildcards for
   every (required, granted) pair, so a large caller-supplied `scope` value - on

--- a/lib/attesto/authorization_code.ex
+++ b/lib/attesto/authorization_code.ex
@@ -68,10 +68,14 @@ defmodule Attesto.AuthorizationCode do
   If `issue/3` is given a `:dpop_jkt`, the code is bound to that DPoP key
   (RFC 9449 §10): redemption MUST present the same `:dpop_jkt` (the
   thumbprint of the key in the token-request's DPoP proof) or it is
-  rejected. A code minted without a binding MAY still be redeemed with a
-  token-request DPoP proof; in that case this module treats the proof as a
-  token-endpoint sender constraint for the access token the host is about to
-  mint, not as a pre-existing authorization-code binding.
+  rejected. A code minted without a binding MAY still be redeemed while a
+  token-request DPoP proof is present - this module does not reject that
+  (unlike `Attesto.RefreshToken`, which is stricter). But it does NOT act on
+  that proof: the returned grant's `dpop_jkt` stays `nil`, and binding the
+  new access token to the token-request proof is the token endpoint's job
+  (via `Attesto.Token`'s `:dpop_jkt` mint opt), not this module's. A host
+  that decides the new token's binding from `grant.dpop_jkt` alone would
+  therefore miss a token-endpoint proof; read the presented proof directly.
   """
 
   alias Attesto.AuthorizationCode.Grant

--- a/lib/attesto/ciba/request.ex
+++ b/lib/attesto/ciba/request.ex
@@ -287,6 +287,17 @@ defmodule Attesto.CIBA.Request do
         require_client_id_claim: false,
         # §7.1.1: `aud` MUST contain the OP's Issuer Identifier.
         audience: issuer,
+        # Explicit typing (RFC 9101 §10.8): a CIBA signed authentication request
+        # and an authorization-endpoint JAR both require `aud` = this issuer and
+        # `iss` = the client, so `aud` cannot tell them apart. CIBA §7.1.1
+        # defines no `typ`, so accept an absent header or the generic `JWT`
+        # media type (RFC 7519 §5.1; the value JOSE-family signers emit by
+        # default) and reject a request bearing the authorization endpoint's
+        # `oauth-authz-req+jwt` - that explicit type must not be honoured as a
+        # backchannel request. Defence-in-depth: the client is separately
+        # authenticated before we get here, so a cross-context request object
+        # already cannot arrive without the client's own credentials.
+        accepted_typ: [nil, "JWT"],
         accepted_algs: algs,
         enforce_fapi_alg_policy:
           Keyword.get(opts, :enforce_fapi_alg_policy, not Keyword.has_key?(opts, :accepted_algs)),

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -584,7 +584,15 @@ defmodule Attesto.DPoP do
   # so the cache TTL is derived from the verifier's own age policy rather
   # than a fixed default that could diverge from it.
   defp replay_ttl(opts) do
-    Keyword.get(opts, :max_age_seconds, @default_max_age_seconds) + @future_skew_seconds
+    # `+ 1` closes an off-by-one at the edge of the proof's life. The freshness
+    # checks are inclusive on integer seconds (`iat > now + skew` and
+    # `iat < now - max_age` both reject only strictly), so a proof minted at the
+    # furthest-future accepted `iat` stays acceptable through real-time
+    # `max_age + skew` whole seconds. A TTL of exactly `max_age + skew` evicts
+    # the `jti` a fraction before that boundary, leaving a sub-second window in
+    # which the same proof is still fresh but no longer remembered - a replay.
+    # One extra second of retention removes it.
+    Keyword.get(opts, :max_age_seconds, @default_max_age_seconds) + @future_skew_seconds + 1
   end
 
   defp check_ath(claims, opts) do

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -52,19 +52,33 @@ defmodule Attesto.DPoP do
     1. The proof's `jti` is length-capped (see `@max_jti_length`) so an
       attacker cannot exhaust the cache by submitting proofs with
       megabyte-sized `jti` values.
-    2. If the caller supplies the `:replay_check` opt, the verifier
-      invokes it with the proof's `jti` AND the TTL the cache must remember
-      it for (the acceptance window: `max_age_seconds` + future skew),
-      AFTER every other check has passed (so an attacker cannot fill the
-      cache with proofs that would have failed anyway). Deriving the TTL
-      from the verifier's age policy keeps the cache from forgetting a
-      `jti` while the proof is still acceptable. The callback returns `:ok`
-      or `{:error, :replay}`. `Attesto.DPoP.ReplayCache` provides a default
-      ETS-backed implementation (`check_and_record/2`).
+    2. The proof's `jti` is recorded once, and rejected if already seen,
+      for the acceptance window (`max_age_seconds` + future skew). The
+      success map returns `jti` and `replay_ttl` so the caller can record
+      it; deriving the TTL from the verifier's age policy keeps the cache
+      from forgetting a `jti` while the proof is still acceptable.
+      `Attesto.DPoP.ReplayCache` provides a default ETS-backed store.
 
-  Protected-resource pipelines MUST pass `:replay_check`. Leaving it out
-  is acceptable only in test scaffolding and at the token endpoint on
-  first use of a proof (the endpoint records the `jti` itself).
+  ### Claim the `jti` only after the whole request has authenticated
+
+  A protected-resource pipeline MUST reject a replayed proof, but it MUST
+  record the `jti` **after** the access token and its `cnf.jkt` binding
+  verify - not during proof verification. Recording it earlier lets a
+  captured-but-otherwise-valid proof (presented with no token, or a token
+  that will fail binding) burn the `jti` first, so the legitimate request
+  carrying that same proof is then rejected as a replay: a targeted denial
+  of service. The token endpoint has the same obligation - record the
+  `jti` only once the grant has validated.
+
+  So the correct shape is: call `verify_proof/2` **without** `:replay_check`,
+  verify the access token and compare its `cnf.jkt` to the returned `jkt`,
+  and only then record the returned `jti` for `replay_ttl` seconds.
+  `Attesto.Plug.Authenticate` does exactly this.
+
+  The `:replay_check` opt records the `jti` inline, during verification,
+  before any of that. It exists for flows with no subsequent binding step
+  and for test scaffolding; a protected-resource or token pipeline should
+  prefer the defer-then-record shape above.
   """
 
   alias Attesto.SecureCompare
@@ -159,11 +173,14 @@ defmodule Attesto.DPoP do
       also accepted to tolerate modest client-side clock skew.
     * `:replay_check` - a two-arity function called with the proof's
       `jti` and the TTL (seconds) the store must remember it for, AFTER
-      every other check has passed. Returns `:ok` if the `jti` has not
-      been seen, or `{:error, :replay}` if it has. Required by
-      protected-resource pipelines; pass
-      `&Attesto.DPoP.ReplayCache.check_and_record/2`. Omit only in test
-      scaffolding.
+      every other proof check has passed. Returns `:ok` if the `jti` has
+      not been seen, or `{:error, :replay}` if it has. This records the
+      `jti` **inline**, before the caller has verified the access token
+      and its `cnf.jkt` binding - so a protected-resource or token
+      pipeline should NOT use it; omit it, verify the token, then record
+      the returned `jti`/`replay_ttl` (see the "Replay protection" section
+      and `Attesto.Plug.Authenticate`). Use it only for a flow with no
+      later binding step, or in test scaffolding.
     * `:nonce_check` - a one-arity function called with the proof's
       `nonce` claim (which may be `nil`). Returns `:ok` or
       `{:error, :use_dpop_nonce}` (RFC 9449 §8), the latter telling the

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -52,11 +52,12 @@ defmodule Attesto.DPoP do
     1. The proof's `jti` is length-capped (see `@max_jti_length`) so an
       attacker cannot exhaust the cache by submitting proofs with
       megabyte-sized `jti` values.
-    2. The proof's `jti` is recorded once, and rejected if already seen,
-      for the acceptance window (`max_age_seconds` + future skew). The
-      success map returns `jti` and `replay_ttl` so the caller can record
-      it; deriving the TTL from the verifier's age policy keeps the cache
-      from forgetting a `jti` while the proof is still acceptable.
+    2. The proof's replay identity is recorded once, and rejected if already
+      seen, for the acceptance window plus a one-second integer-boundary margin
+      (`max_age_seconds` + future skew + 1 — see `replay_ttl/1`). The success
+      map returns `replay_key`/`replay_ttl` so the caller can record it;
+      deriving the TTL from the verifier's age policy keeps the cache from
+      forgetting the identity while the proof is still acceptable.
       `Attesto.DPoP.ReplayCache` provides a default ETS-backed store.
 
   ### Claim the `jti` only after the whole request has authenticated
@@ -122,6 +123,7 @@ defmodule Attesto.DPoP do
           iat: non_neg_integer(),
           jkt: String.t(),
           jti: String.t(),
+          replay_key: String.t(),
           replay_ttl: pos_integer()
         }
 
@@ -223,25 +225,41 @@ defmodule Attesto.DPoP do
          {:ok, jti} <- check_jti(claims),
          {:ok, ath} <- check_ath(claims, opts),
          :ok <- check_nonce(claims, opts),
-         :ok <- check_replay(jti, opts) do
+         jkt = JOSE.JWK.thumbprint(jwk),
+         replay_key = replay_key(jkt, jti),
+         :ok <- check_replay(replay_key, opts) do
       {:ok,
        %{
          ath: ath,
          htm: claims["htm"],
          htu: claims["htu"],
          iat: iat,
-         jkt: JOSE.JWK.thumbprint(jwk),
+         jkt: jkt,
          jti: jti,
-         # The window this proof's `jti` must be remembered for, so a caller
-         # that claims the identifier itself - rather than through
-         # `:replay_check` here - uses the same acceptance window this
-         # verification applied instead of deriving it a second time.
+         # The replay identity to record: the `jti` NAMESPACED by the proof key
+         # thumbprint. RFC 9449 §4.2 scopes a proof to its key, and `jti`
+         # uniqueness is only guaranteed per key - two clients (or an attacker's
+         # own key) may legitimately mint the same `jti`. Keying replay on `jti`
+         # alone would let one key's proof evict another's, both a cross-client
+         # false replay and a targeted DoS. A caller that defers the claim MUST
+         # record `replay_key`, not the raw `jti` (which is retained for
+         # telemetry). `jkt` is fixed-length base64url with no `:`, so the
+         # prefix is unambiguous.
+         replay_key: replay_key,
+         # The window this identity must be remembered for, so a caller that
+         # claims it itself - rather than through `:replay_check` here - uses the
+         # same acceptance window this verification applied instead of deriving
+         # it a second time.
          replay_ttl: replay_ttl(opts)
        }}
     end
   end
 
   def verify_proof(_proof, _opts), do: {:error, :invalid_proof}
+
+  # Namespace the replay identity by the proof-key thumbprint (RFC 9449 §4.2):
+  # `jti` is unique only within a key, so the cache must not collide across keys.
+  defp replay_key(jkt, jti), do: jkt <> ":" <> jti
 
   @doc """
   RFC 7638 SHA-256 JWK thumbprint, base64url-encoded without padding.

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -176,15 +176,18 @@ defmodule Attesto.DPoP do
       A constant #{@future_skew_seconds}-second window into the future is
       also accepted to tolerate modest client-side clock skew.
     * `:replay_check` - a two-arity function called with the proof's
-      `jti` and the TTL (seconds) the store must remember it for, AFTER
-      every other proof check has passed. Returns `:ok` if the `jti` has
-      not been seen, or `{:error, :replay}` if it has. This records the
-      `jti` **inline**, before the caller has verified the access token
-      and its `cnf.jkt` binding - so a protected-resource or token
-      pipeline should NOT use it; omit it, verify the token, then record
-      the returned `jti`/`replay_ttl` (see the "Replay protection" section
-      and `Attesto.Plug.Authenticate`). Use it only for a flow with no
-      later binding step, or in test scaffolding.
+      **replay identity** and the TTL (seconds) the store must remember it
+      for, AFTER every other proof check has passed. Returns `:ok` if the
+      identity has not been seen, or `{:error, :replay}` if it has. The
+      identity is an OPAQUE string (the `replay_key` in the success map: a
+      fixed-length digest namespacing the `jti` by the proof key - do NOT
+      assume it is the raw `jti` or parse it). This records it **inline**,
+      before the caller has verified the access token and its `cnf.jkt`
+      binding - so a protected-resource or token pipeline should NOT use it;
+      omit it, verify the token, then record the returned
+      `replay_key`/`replay_ttl` (see the "Replay protection" section and
+      `Attesto.Plug.Authenticate`). Use it only for a flow with no later
+      binding step, or in test scaffolding.
     * `:nonce_check` - a one-arity function called with the proof's
       `nonce` claim (which may be `nil`). Returns `:ok` or
       `{:error, :use_dpop_nonce}` (RFC 9449 §8), the latter telling the
@@ -229,7 +232,7 @@ defmodule Attesto.DPoP do
          :ok <- check_nonce(claims, opts),
          jkt = JOSE.JWK.thumbprint(jwk),
          replay_key = replay_key(jkt, jti),
-         :ok <- check_replay(replay_key, opts) do
+         :ok <- check_replay(replay_key, jti, opts) do
       {:ok,
        %{
          ath: ath,
@@ -590,13 +593,15 @@ defmodule Attesto.DPoP do
     end
   end
 
-  defp check_replay(jti, opts) do
+  defp check_replay(replay_key, jti, opts) do
     case Keyword.get(opts, :replay_check) do
       nil ->
         :ok
 
       fun when is_function(fun, 2) ->
-        case fun.(jti, replay_ttl(opts)) do
+        # The store records the namespaced, opaque `replay_key`; telemetry emits
+        # the raw client `jti` so a repeat can be correlated with the proof.
+        case fun.(replay_key, replay_ttl(opts)) do
           :ok ->
             :ok
 

--- a/lib/attesto/dpop.ex
+++ b/lib/attesto/dpop.ex
@@ -69,14 +69,16 @@ defmodule Attesto.DPoP do
   that will fail binding) burn the `jti` first, so the legitimate request
   carrying that same proof is then rejected as a replay: a targeted denial
   of service. The token endpoint has the same obligation - record the
-  `jti` only once the grant has validated.
+  identity only once the grant has validated.
 
   So the correct shape is: call `verify_proof/2` **without** `:replay_check`,
   verify the access token and compare its `cnf.jkt` to the returned `jkt`,
-  and only then record the returned `jti` for `replay_ttl` seconds.
+  and only then record the returned **`replay_key`** for `replay_ttl` seconds.
+  Record `replay_key`, not the raw `jti`: it namespaces the identifier by the
+  proof key (see the success map), so one key's proof cannot evict another's.
   `Attesto.Plug.Authenticate` does exactly this.
 
-  The `:replay_check` opt records the `jti` inline, during verification,
+  The `:replay_check` opt records the identity inline, during verification,
   before any of that. It exists for flows with no subsequent binding step
   and for test scaffolding; a protected-resource or token pipeline should
   prefer the defer-then-record shape above.
@@ -236,15 +238,14 @@ defmodule Attesto.DPoP do
          iat: iat,
          jkt: jkt,
          jti: jti,
-         # The replay identity to record: the `jti` NAMESPACED by the proof key
-         # thumbprint. RFC 9449 §4.2 scopes a proof to its key, and `jti`
-         # uniqueness is only guaranteed per key - two clients (or an attacker's
-         # own key) may legitimately mint the same `jti`. Keying replay on `jti`
-         # alone would let one key's proof evict another's, both a cross-client
-         # false replay and a targeted DoS. A caller that defers the claim MUST
-         # record `replay_key`, not the raw `jti` (which is retained for
-         # telemetry). `jkt` is fixed-length base64url with no `:`, so the
-         # prefix is unambiguous.
+         # The replay identity to record: a fixed-length digest of the `jti`
+         # NAMESPACED by the proof key thumbprint. RFC 9449 §4.2 scopes a proof
+         # to its key, and `jti` uniqueness is only guaranteed per key - two
+         # clients (or an attacker's own key) may legitimately mint the same
+         # `jti`. Keying replay on `jti` alone would let one key's proof evict
+         # another's, both a cross-client false replay and a targeted DoS. A
+         # caller that defers the claim MUST record `replay_key`, not the raw
+         # `jti` (which is retained for telemetry).
          replay_key: replay_key,
          # The window this identity must be remembered for, so a caller that
          # claims it itself - rather than through `:replay_check` here - uses the
@@ -259,7 +260,14 @@ defmodule Attesto.DPoP do
 
   # Namespace the replay identity by the proof-key thumbprint (RFC 9449 §4.2):
   # `jti` is unique only within a key, so the cache must not collide across keys.
-  defp replay_key(jkt, jti), do: jkt <> ":" <> jti
+  # Hash the (jkt, jti) pair to a FIXED-LENGTH (43-char base64url) identifier so
+  # the recorded key is bounded regardless of `jti` length - a raw `jti` may be
+  # up to `@max_jti_length` bytes, which a caller's store column need not size
+  # for. `jkt` is fixed-length base64url with no `:`, so `jkt <> ":" <> jti` is
+  # an injective encoding of the pair before hashing.
+  defp replay_key(jkt, jti) do
+    :sha256 |> :crypto.hash(jkt <> ":" <> jti) |> Base.url_encode64(padding: false)
+  end
 
   @doc """
   RFC 7638 SHA-256 JWK thumbprint, base64url-encoded without padding.

--- a/lib/attesto/dpop/replay_cache.ex
+++ b/lib/attesto/dpop/replay_cache.ex
@@ -32,9 +32,12 @@ defmodule Attesto.DPoP.ReplayCache do
   shape (`(jti, ttl_seconds) -> :ok | {:error, :replay}`) lets any
   replacement plug in without changes to `Attesto.DPoP`. The verifier
   passes its whole acceptance window as `ttl_seconds` - `:max_age_seconds`
-  plus the future-skew allowance it also tolerates, not `:max_age_seconds`
-  alone - so a shared store sized by that value cannot forget a `jti`
-  while a proof carrying it would still be accepted.
+  plus the future-skew allowance it also tolerates, plus a one-second
+  integer-boundary margin, not `:max_age_seconds` alone - so a shared store
+  sized by that value cannot forget an identity while a proof carrying it would
+  still be accepted. (The identity the verifier passes is the `jti` namespaced
+  by the proof-key thumbprint; the `jti`/`ttl_seconds` argument names are
+  historical.)
 
   The boot-time guard **raises** on startup if `Node.list/0` is non-empty
   and `:multi_node_acknowledged?` is not set - a clustered BEAM with a

--- a/lib/attesto/identity_assertion.ex
+++ b/lib/attesto/identity_assertion.ex
@@ -300,6 +300,11 @@ defmodule Attesto.IdentityAssertion do
     if nbf <= unix_now(opts) + @clock_skew_seconds, do: :ok, else: {:error, :not_yet_valid}
   end
 
+  # A PRESENT `nbf` that is not an integer NumericDate is malformed, and must be
+  # rejected rather than treated as absent - otherwise a garbage `nbf` bypasses
+  # the not-yet-valid check entirely. Mirrors `Attesto.Token.check_not_before/2`.
+  defp check_nbf(%{"nbf" => _}, _opts), do: {:error, :invalid_claims}
+
   defp check_nbf(_claims, _opts), do: :ok
 
   # Bound the assertion's lifetime when the caller sets `:max_lifetime_seconds`.

--- a/lib/attesto/identity_assertion.ex
+++ b/lib/attesto/identity_assertion.ex
@@ -72,6 +72,7 @@ defmodule Attesto.IdentityAssertion do
           | :invalid_issuer
           | :invalid_audience
           | :missing_claim
+          | :invalid_claims
           | :client_mismatch
           | :expired
           | :not_yet_valid

--- a/lib/attesto/jarm.ex
+++ b/lib/attesto/jarm.ex
@@ -62,6 +62,7 @@ defmodule Attesto.JARM do
     claims =
       params
       |> drop_nil()
+      |> stringify_keys()
       |> Map.merge(%{
         "iss" => config.issuer,
         "aud" => client_id,
@@ -80,6 +81,22 @@ defmodule Attesto.JARM do
     params
     |> Enum.reject(fn {_key, value} -> is_nil(value) end)
     |> Map.new()
+  end
+
+  # The reserved claims (`iss`, `aud`, `iat`, `exp`) are set by the merge below,
+  # and a string key there overwrites a caller's string key of the same name -
+  # the server value wins. An *atom* key (`:iss`) is a distinct map key, so it
+  # would survive the merge and serialize to the same JSON member name as the
+  # server's `"iss"`, producing a duplicate member whose value a lenient JSON
+  # parser might prefer. Collapse every atom key onto its string form first so
+  # the merge is authoritative and the JWT can never carry a duplicate claim.
+  # (`params`'s contract is string keys; this hardens the public core against a
+  # caller that mixes in atoms rather than trusting the contract.)
+  defp stringify_keys(params) do
+    Map.new(params, fn
+      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
+      {key, value} -> {key, value}
+    end)
   end
 
   # `:lifetime` may only shorten the default - a larger value (or a

--- a/lib/attesto/jarm.ex
+++ b/lib/attesto/jarm.ex
@@ -85,17 +85,26 @@ defmodule Attesto.JARM do
 
   # The reserved claims (`iss`, `aud`, `iat`, `exp`) are set by the merge below,
   # and a string key there overwrites a caller's string key of the same name -
-  # the server value wins. An *atom* key (`:iss`) is a distinct map key, so it
-  # would survive the merge and serialize to the same JSON member name as the
-  # server's `"iss"`, producing a duplicate member whose value a lenient JSON
-  # parser might prefer. Collapse every atom key onto its string form first so
-  # the merge is authoritative and the JWT can never carry a duplicate claim.
-  # (`params`'s contract is string keys; this hardens the public core against a
-  # caller that mixes in atoms rather than trusting the contract.)
+  # the server value wins. A key of any OTHER type that still serializes to the
+  # same JSON member name (an atom `:iss`, a charlist `~c"iss"`) is a distinct
+  # map key, so it would survive the merge and produce a DUPLICATE JSON member
+  # whose value a lenient parser might prefer. Guarantee the invariant "every
+  # key is a binary" here: convert atoms, pass binaries, and reject anything
+  # else - so the merge is authoritative and the JWT can never carry a duplicate
+  # claim. (`params`'s contract is string keys; this hardens the public core
+  # against a caller that violates it rather than trusting the contract.)
   defp stringify_keys(params) do
     Map.new(params, fn
-      {key, value} when is_atom(key) -> {Atom.to_string(key), value}
-      {key, value} -> {key, value}
+      {key, value} when is_binary(key) ->
+        {key, value}
+
+      {key, value} when is_atom(key) ->
+        {Atom.to_string(key), value}
+
+      {key, _value} ->
+        raise ArgumentError,
+              "JARM response params must have string keys (atoms are converted); " <>
+                "a #{inspect(key)} key could forge a duplicate reserved claim"
     end)
   end
 

--- a/lib/attesto/plug/authenticate.ex
+++ b/lib/attesto/plug/authenticate.ex
@@ -134,10 +134,10 @@ if Code.ensure_loaded?(Plug.Conn) do
       # `verify_dpop_proof/4`. Claiming earlier would let an unauthenticated
       # request write to the replay store.
       with {:ok, scheme, token} <- authorization(conn, opts),
-           {:ok, dpop_jkt, dpop_replay_key, replay_ttl} <- verify_dpop(conn, scheme, token, opts),
+           {:ok, dpop_jkt, dpop_replay_key, dpop_jti, replay_ttl} <- verify_dpop(conn, scheme, token, opts),
            {:ok, mtls_thumb} <- cert_thumbprint(conn, opts),
            {:ok, claims} <- verify_token(config, token, dpop_jkt, mtls_thumb, opts),
-           :ok <- claim_dpop_jti(dpop_replay_key, replay_ttl, opts) do
+           :ok <- claim_dpop_jti(dpop_replay_key, dpop_jti, replay_ttl, opts) do
         conn = assign(conn, Keyword.get(opts, :claims_key, @default_claims_key), claims)
 
         # RFC 9470 §3: after the token is verified, enforce any route step-up
@@ -330,7 +330,7 @@ if Code.ensure_loaded?(Plug.Conn) do
     defp verify_dpop(conn, :bearer, _token, _opts) do
       case get_req_header(conn, "dpop") do
         [_ | _] -> {:dpop_error, :dpop_scheme_required}
-        _ -> {:ok, nil, nil, nil}
+        _ -> {:ok, nil, nil, nil, nil}
       end
     end
 
@@ -371,23 +371,28 @@ if Code.ensure_loaded?(Plug.Conn) do
           |> put_opt(:nonce_check, Keyword.get(opts, :nonce_check))
 
         case DPoP.verify_proof(proof, verify_opts) do
-          # Claim the namespaced `replay_key` (jkt:jti), not the raw `jti` - see
+          # Record the namespaced, opaque `replay_key`, not the raw `jti` - see
           # `Attesto.DPoP`'s replay-identity note. `jkt` still flows out for the
-          # token `cnf.jkt` comparison.
-          {:ok, %{jkt: jkt, replay_key: replay_key, replay_ttl: ttl}} -> {:ok, jkt, replay_key, ttl}
-          {:error, reason} -> {:dpop_error, reason}
+          # token `cnf.jkt` comparison; the raw `jti` flows out for replay
+          # telemetry only (correlation with the client's proof).
+          {:ok, %{jkt: jkt, replay_key: replay_key, jti: jti, replay_ttl: ttl}} ->
+            {:ok, jkt, replay_key, jti, ttl}
+
+          {:error, reason} ->
+            {:dpop_error, reason}
         end
       else
         {:dpop_error, :replay_check_unconfigured}
       end
     end
 
-    # Claim the proof's replay identity (the namespaced `jkt:jti`), now that the
-    # token behind it is known to be valid. A Bearer/mTLS request carries no
+    # Claim the proof's replay identity (the opaque, namespaced `replay_key`),
+    # now that the token behind it is known to be valid. The raw `jti` rides
+    # alongside for replay telemetry only. A Bearer/mTLS request carries no
     # proof and so has nothing to claim.
-    defp claim_dpop_jti(nil, _ttl, _opts), do: :ok
+    defp claim_dpop_jti(nil, _jti, _ttl, _opts), do: :ok
 
-    defp claim_dpop_jti(replay_key, ttl_seconds, opts) when is_binary(replay_key) do
+    defp claim_dpop_jti(replay_key, jti, ttl_seconds, opts) when is_binary(replay_key) do
       case Keyword.get(opts, :replay_check) do
         fun when is_function(fun, 2) ->
           # The accepted results mirror `Attesto.DPoP.check_replay/2` exactly.
@@ -405,8 +410,10 @@ if Code.ensure_loaded?(Plug.Conn) do
               # `Attesto.DPoP.check_replay/2`, because this plug deliberately
               # does not hand `:replay_check` to `verify_proof/2` - the claim
               # is deferred until the token has verified - so the core's
-              # emission point is never reached on this path.
-              Attesto.Telemetry.dpop_replay_detected(replay_key)
+              # emission point is never reached on this path. Telemetry gets the
+              # raw `jti` (correlation with the client's proof), the store the
+              # opaque `replay_key`.
+              Attesto.Telemetry.dpop_replay_detected(jti)
               {:dpop_error, :replay}
 
             other ->

--- a/lib/attesto/plug/authenticate.ex
+++ b/lib/attesto/plug/authenticate.ex
@@ -130,14 +130,14 @@ if Code.ensure_loaded?(Plug.Conn) do
       config = resolve_config(opts)
 
       # The DPoP proof is verified before the token (its `jkt` is an input to
-      # token verification), but its `jti` is claimed only after - see
+      # token verification), but its replay identity is claimed only after - see
       # `verify_dpop_proof/4`. Claiming earlier would let an unauthenticated
       # request write to the replay store.
       with {:ok, scheme, token} <- authorization(conn, opts),
-           {:ok, dpop_jkt, dpop_jti, replay_ttl} <- verify_dpop(conn, scheme, token, opts),
+           {:ok, dpop_jkt, dpop_replay_key, replay_ttl} <- verify_dpop(conn, scheme, token, opts),
            {:ok, mtls_thumb} <- cert_thumbprint(conn, opts),
            {:ok, claims} <- verify_token(config, token, dpop_jkt, mtls_thumb, opts),
-           :ok <- claim_dpop_jti(dpop_jti, replay_ttl, opts) do
+           :ok <- claim_dpop_jti(dpop_replay_key, replay_ttl, opts) do
         conn = assign(conn, Keyword.get(opts, :claims_key, @default_claims_key), claims)
 
         # RFC 9470 §3: after the token is verified, enforce any route step-up
@@ -371,7 +371,10 @@ if Code.ensure_loaded?(Plug.Conn) do
           |> put_opt(:nonce_check, Keyword.get(opts, :nonce_check))
 
         case DPoP.verify_proof(proof, verify_opts) do
-          {:ok, %{jkt: jkt, jti: jti, replay_ttl: ttl}} -> {:ok, jkt, jti, ttl}
+          # Claim the namespaced `replay_key` (jkt:jti), not the raw `jti` - see
+          # `Attesto.DPoP`'s replay-identity note. `jkt` still flows out for the
+          # token `cnf.jkt` comparison.
+          {:ok, %{jkt: jkt, replay_key: replay_key, replay_ttl: ttl}} -> {:ok, jkt, replay_key, ttl}
           {:error, reason} -> {:dpop_error, reason}
         end
       else
@@ -379,12 +382,12 @@ if Code.ensure_loaded?(Plug.Conn) do
       end
     end
 
-    # Claim the proof identifier, now that the token behind it is known to be
-    # valid. A Bearer/mTLS request carries no proof and so has nothing to
-    # claim.
+    # Claim the proof's replay identity (the namespaced `jkt:jti`), now that the
+    # token behind it is known to be valid. A Bearer/mTLS request carries no
+    # proof and so has nothing to claim.
     defp claim_dpop_jti(nil, _ttl, _opts), do: :ok
 
-    defp claim_dpop_jti(jti, ttl_seconds, opts) when is_binary(jti) do
+    defp claim_dpop_jti(replay_key, ttl_seconds, opts) when is_binary(replay_key) do
       case Keyword.get(opts, :replay_check) do
         fun when is_function(fun, 2) ->
           # The accepted results mirror `Attesto.DPoP.check_replay/2` exactly.
@@ -393,7 +396,7 @@ if Code.ensure_loaded?(Plug.Conn) do
           # 401 `invalid_dpop_proof`, blaming the client for a server fault and
           # hiding the outage. An unsupported return is a host integration bug
           # and is raised, not translated.
-          case fun.(jti, ttl_seconds) do
+          case fun.(replay_key, ttl_seconds) do
             :ok ->
               :ok
 
@@ -403,7 +406,7 @@ if Code.ensure_loaded?(Plug.Conn) do
               # does not hand `:replay_check` to `verify_proof/2` - the claim
               # is deferred until the token has verified - so the core's
               # emission point is never reached on this path.
-              Attesto.Telemetry.dpop_replay_detected(jti)
+              Attesto.Telemetry.dpop_replay_detected(replay_key)
               {:dpop_error, :replay}
 
             other ->

--- a/lib/attesto/refresh_token.ex
+++ b/lib/attesto/refresh_token.ex
@@ -21,8 +21,12 @@ defmodule Attesto.RefreshToken do
   A refresh token can be bound to a DPoP key (its issuing context carries
   a `:dpop_jkt`). Rotation then requires the caller to present the
   matching `:dpop_jkt` (the thumbprint of the key in the token-request's
-  DPoP proof); an unbound token must be rotated without one. The binding
-  matrix mirrors `Attesto.Token` and `Attesto.AuthorizationCode`.
+  DPoP proof); an unbound token must be rotated without one - presenting a
+  proof for an unbound token is `:dpop_proof_unexpected`. That fail-closed
+  matrix mirrors `Attesto.Token`. It does NOT match
+  `Attesto.AuthorizationCode`, which permits an unbound code to be redeemed
+  alongside a token-request proof (the proof there binds the new access
+  token, not the code); rotation is deliberately the stricter of the two.
   """
 
   alias Attesto.Scope

--- a/lib/attesto/request_object.ex
+++ b/lib/attesto/request_object.ex
@@ -438,11 +438,23 @@ defmodule Attesto.RequestObject do
   defp typ_accepted?(nil, accepted), do: Enum.member?(accepted, nil)
 
   defp typ_accepted?(typ, accepted) when is_binary(typ) do
-    down = String.downcase(typ)
-    Enum.any?(accepted, fn a -> is_binary(a) and String.downcase(a) == down end)
+    norm = normalize_typ(typ)
+    Enum.any?(accepted, fn a -> is_binary(a) and normalize_typ(a) == norm end)
   end
 
   defp typ_accepted?(_typ, _accepted), do: false
+
+  # RFC 7515 §4.1.9 / RFC 7519 §5.1: `typ` is a media type whose `application/`
+  # prefix MAY be omitted, and recipients treat e.g. `JWT` and `application/JWT`
+  # as the same type (case-insensitively). Normalize both sides so an accepted
+  # `JWT` also accepts `application/jwt`, and a rejected `oauth-authz-req+jwt`
+  # also rejects its `application/`-prefixed spelling.
+  defp normalize_typ(typ) do
+    case String.downcase(typ) do
+      "application/" <> rest -> rest
+      down -> down
+    end
+  end
 
   defp check_compact_form(jwt) do
     case String.split(jwt, ".") do

--- a/lib/attesto/request_object.ex
+++ b/lib/attesto/request_object.ex
@@ -444,15 +444,23 @@ defmodule Attesto.RequestObject do
 
   defp typ_accepted?(_typ, _accepted), do: false
 
-  # RFC 7515 §4.1.9 / RFC 7519 §5.1: `typ` is a media type whose `application/`
-  # prefix MAY be omitted, and recipients treat e.g. `JWT` and `application/JWT`
-  # as the same type (case-insensitively). Normalize both sides so an accepted
-  # `JWT` also accepts `application/jwt`, and a rejected `oauth-authz-req+jwt`
-  # also rejects its `application/`-prefixed spelling.
+  # RFC 7515 §4.1.9 / RFC 7519 §5.1: `typ` is a media type, and per convention
+  # the `application/` prefix MAY be omitted when producing/comparing it - so
+  # `JWT` and `application/JWT` are the same type (case-insensitively). That
+  # convention applies only to a bare subtype: dropping the prefix is valid when
+  # what remains has no further `/` (e.g. `application/jwt` -> `jwt`), but NOT
+  # for a value that still contains a slash (`application/text/example` is a
+  # different, malformed type, not `text/example`). Normalize both sides that
+  # way so an accepted `JWT` also accepts `application/jwt`, and a rejected
+  # `oauth-authz-req+jwt` also rejects its `application/`-prefixed spelling,
+  # without collapsing unrelated multi-slash values together.
   defp normalize_typ(typ) do
     case String.downcase(typ) do
-      "application/" <> rest -> rest
-      down -> down
+      "application/" <> rest = full ->
+        if String.contains?(rest, "/"), do: full, else: rest
+
+      down ->
+        down
     end
   end
 

--- a/lib/attesto/request_object.ex
+++ b/lib/attesto/request_object.ex
@@ -380,11 +380,26 @@ defmodule Attesto.RequestObject do
     claims
     |> Map.drop(~w(iss sub aud exp nbf iat jti))
     |> Enum.reduce(%{}, fn
-      {key, value}, acc when is_binary(value) -> Map.put(acc, key, value)
-      {key, value}, acc when is_boolean(value) or is_integer(value) -> Map.put(acc, key, to_string(value))
-      {key, value}, acc when is_list(value) -> Map.put(acc, key, Enum.join(value, " "))
-      {key, value}, acc when is_map(value) -> Map.put(acc, key, JSON.encode!(value))
-      {_key, _value}, acc -> acc
+      {key, value}, acc when is_binary(value) ->
+        Map.put(acc, key, value)
+
+      {key, value}, acc when is_boolean(value) or is_integer(value) ->
+        Map.put(acc, key, to_string(value))
+
+      # A list is space-joined ONLY when every element is a string (an array
+      # `resource`/`scope` in a signed request object). A list carrying a
+      # non-string element (`"scope": [{"x": 1}]`) is dropped, not joined:
+      # `Enum.join/2` raises `Protocol.UndefinedError` on a map/list element, and
+      # this reduce runs on a signature-VALID request object, so an unguarded
+      # join let a registered client crash the authorization-request process.
+      {key, value}, acc when is_list(value) ->
+        if Enum.all?(value, &is_binary/1), do: Map.put(acc, key, Enum.join(value, " ")), else: acc
+
+      {key, value}, acc when is_map(value) ->
+        Map.put(acc, key, JSON.encode!(value))
+
+      {_key, _value}, acc ->
+        acc
     end)
   end
 

--- a/lib/attesto/scope.ex
+++ b/lib/attesto/scope.ex
@@ -178,10 +178,15 @@ defmodule Attesto.Scope do
     # per-pair allocation. Since `required` is the caller-supplied requested
     # scope at a token endpoint, that made a large `scope` parameter a
     # denial-of-service lever (RFC 6749 §3.3 places no bound on the value). This
-    # form is O(|granted| + |required|) and allocates once per side, so the same
-    # 500k-token input that took ~20s is now flat. The result is identical to
-    # the naive form (verified by property test): the index encodes exactly the
-    # three ways `covers?/3` can hold.
+    # form removes that cross-product scan: `granted` is classified once and
+    # each required scope is then an O(1) index lookup, so the 500k-token input
+    # that took ~20s is now ~40ms. For every input the typespec allows - proper
+    # lists of binaries - the result is identical to the naive form (the index
+    # encodes exactly the three ways `covers?/3` can hold; a 500-run generated
+    # property pins it). An IMPROPER list is the one behaviour change: the naive
+    # form could short-circuit before reaching the improper tail, while the
+    # eager classification here traverses it and raises - a louder failure on a
+    # value the contract already forbids.
     index = index_granted(catalog, granted)
     Enum.all?(required, &granted_by_index?(catalog, index, &1))
   end

--- a/lib/attesto/scope.ex
+++ b/lib/attesto/scope.ex
@@ -212,19 +212,21 @@ defmodule Attesto.Scope do
   defp index_granted(catalog, granted) do
     List.wrap(granted)
     |> Enum.reduce(%{full?: false, resources: MapSet.new(), exact: MapSet.new()}, fn
-      scope, acc when is_binary(scope) ->
-        if scope == @full_wildcard do
-          %{acc | full?: true}
-        else
-          case parse_resource_wildcard(catalog, scope) do
-            {:ok, resource} -> %{acc | resources: MapSet.put(acc.resources, resource)}
-            :error -> %{acc | exact: MapSet.put(acc.exact, scope)}
-          end
-        end
-
-      _scope, acc ->
-        acc
+      scope, acc when is_binary(scope) -> classify_granted(catalog, scope, acc)
+      _scope, acc -> acc
     end)
+  end
+
+  # One granted scope into the index: the full wildcard sets `full?`, a
+  # resource-level wildcard whose resource is catalogued adds to `resources`,
+  # anything else is an exact scope.
+  defp classify_granted(_catalog, @full_wildcard, acc), do: %{acc | full?: true}
+
+  defp classify_granted(catalog, scope, acc) do
+    case parse_resource_wildcard(catalog, scope) do
+      {:ok, resource} -> %{acc | resources: MapSet.put(acc.resources, resource)}
+      :error -> %{acc | exact: MapSet.put(acc.exact, scope)}
+    end
   end
 
   # The index equivalent of `known?(required) and Enum.any?(granted, &covers?/3)`.

--- a/lib/attesto/scope.ex
+++ b/lib/attesto/scope.ex
@@ -171,7 +171,19 @@ defmodule Attesto.Scope do
   def grants_all?(%__MODULE__{}, _granted, []), do: raise_empty_required!("[]")
 
   def grants_all?(%__MODULE__{} = catalog, granted, required) when is_list(required) do
-    Enum.all?(required, &grants?(catalog, granted, &1))
+    # Classify the granted set ONCE, then test each required scope against that
+    # index in O(1). The naive form - `Enum.all?(required, &grants?(.., granted,
+    # &1))` - rescans `granted` and re-`String.split`s a resource wildcard for
+    # every (required, granted) pair, which is O(|required| x |granted|) with a
+    # per-pair allocation. Since `required` is the caller-supplied requested
+    # scope at a token endpoint, that made a large `scope` parameter a
+    # denial-of-service lever (RFC 6749 §3.3 places no bound on the value). This
+    # form is O(|granted| + |required|) and allocates once per side, so the same
+    # 500k-token input that took ~20s is now flat. The result is identical to
+    # the naive form (verified by property test): the index encodes exactly the
+    # three ways `covers?/3` can hold.
+    index = index_granted(catalog, granted)
+    Enum.all?(required, &granted_by_index?(catalog, index, &1))
   end
 
   @doc """
@@ -187,6 +199,40 @@ defmodule Attesto.Scope do
     do: Enum.reject(requested, &customer_grant_form?(catalog, &1))
 
   # ----- internal -----
+
+  # Classify each granted scope once into the three shapes `covers?/3`
+  # distinguishes: the full wildcard, a resource-level wildcard (`<r>.*` whose
+  # resource is catalogued), or an exact scope. Non-binary entries are dropped,
+  # matching `covers?/3`'s `false` fallthrough.
+  defp index_granted(catalog, granted) do
+    List.wrap(granted)
+    |> Enum.reduce(%{full?: false, resources: MapSet.new(), exact: MapSet.new()}, fn
+      scope, acc when is_binary(scope) ->
+        if scope == @full_wildcard do
+          %{acc | full?: true}
+        else
+          case parse_resource_wildcard(catalog, scope) do
+            {:ok, resource} -> %{acc | resources: MapSet.put(acc.resources, resource)}
+            :error -> %{acc | exact: MapSet.put(acc.exact, scope)}
+          end
+        end
+
+      _scope, acc ->
+        acc
+    end)
+  end
+
+  # The index equivalent of `known?(required) and Enum.any?(granted, &covers?/3)`.
+  # `known?` is factored to the front because every `covers?/3` branch requires
+  # it; the disjunction then mirrors the three branches exactly.
+  defp granted_by_index?(catalog, index, required) when is_binary(required) do
+    known?(catalog, required) and
+      (index.full? or
+         MapSet.member?(index.exact, required) or
+         MapSet.member?(index.resources, scope_resource(required)))
+  end
+
+  defp granted_by_index?(_catalog, _index, _required), do: false
 
   defp covers?(catalog, @full_wildcard, required), do: known?(catalog, required)
 

--- a/lib/attesto/session_state.ex
+++ b/lib/attesto/session_state.ex
@@ -72,8 +72,22 @@ defmodule Attesto.SessionState do
   @spec compute(String.t(), String.t(), String.t(), String.t()) :: String.t()
   def compute(client_id, origin, op_browser_state, salt \\ generate_salt())
       when is_binary(client_id) and is_binary(origin) and is_binary(op_browser_state) and is_binary(salt) do
+    validate_salt!(salt)
     digest = :crypto.hash(:sha256, "#{client_id} #{origin} #{op_browser_state} #{salt}")
     Base.encode16(digest, case: :lower) <> "." <> salt
+  end
+
+  # `generate_salt/0` always yields a safe base64url salt; this guards a
+  # caller-supplied one. A space would put a space in the `session_state`
+  # (§2 forbids it) and a `.` would fight the `hash "." salt` delimiter the OP
+  # iframe splits on, so a value computed over such a salt could never compare
+  # equal in the browser. Fail loudly at the source rather than emit it.
+  defp validate_salt!(salt) do
+    if salt == "" or String.contains?(salt, [" ", "."]) do
+      raise ArgumentError,
+            "session_state salt must be a non-empty string with no space or \".\" " <>
+              "(use generate_salt/0); got: #{inspect(salt)}"
+    end
   end
 
   @doc """
@@ -128,6 +142,7 @@ defmodule Attesto.SessionState do
   """
   @spec mint_browser_state(binary(), binary()) :: String.t()
   def mint_browser_state(secret, login_binding) when is_binary(secret) and is_binary(login_binding) do
+    validate_secret!(secret)
     payload = generate_browser_state() <> "." <> login_tag(secret, login_binding)
     payload <> "." <> mac(secret, payload)
   end
@@ -155,10 +170,17 @@ defmodule Attesto.SessionState do
   @spec browser_state_valid?(binary(), binary(), binary()) :: boolean()
   def browser_state_valid?(secret, value, login_binding)
       when is_binary(secret) and is_binary(value) and is_binary(login_binding) do
+    validate_secret!(secret)
+
     case String.split(value, ".", parts: 3) do
       [random, login_tag, mac] ->
-        SecureCompare.equal?(mac, mac(secret, random <> "." <> login_tag)) and
-          SecureCompare.equal?(login_tag, login_tag(secret, login_binding))
+        # Compute both comparisons before combining, so the result does not
+        # depend on which one failed first. (The `mac` check already gates on a
+        # secret-keyed value an attacker cannot forge, so this is hygiene, not a
+        # load-bearing defence - but the boolean should still be work-uniform.)
+        mac_ok = SecureCompare.equal?(mac, mac(secret, random <> "." <> login_tag))
+        tag_ok = SecureCompare.equal?(login_tag, login_tag(secret, login_binding))
+        mac_ok and tag_ok
 
       _ ->
         false
@@ -176,6 +198,22 @@ defmodule Attesto.SessionState do
 
   defp hmac(secret, data) do
     :hmac |> :crypto.mac(:sha256, secret, data) |> Base.url_encode64(padding: false)
+  end
+
+  # HMAC-SHA256 accepts any key length, so an empty or short OP secret produces
+  # a MAC an attacker can recompute (`:crypto.mac(:hmac, :sha256, "", data)` is
+  # deterministic and needs no secret) - the browser state would no longer be
+  # OP-owned. RFC 2104 §3 recommends a key at least as long as the hash output
+  # (32 bytes for SHA-256). The secret is OP configuration, not attacker input,
+  # so a too-short one is a misconfiguration to surface loudly, not tolerate.
+  @min_secret_bytes 32
+  defp validate_secret!(secret) do
+    if byte_size(secret) < @min_secret_bytes do
+      raise ArgumentError,
+            "OP browser-state secret must be at least #{@min_secret_bytes} bytes " <>
+              "(RFC 2104: an HMAC-SHA256 key shorter than the 32-byte output is weak); " <>
+              "got #{byte_size(secret)} bytes"
+    end
   end
 
   # A default port is omitted from a browser origin; any other port is kept.

--- a/lib/attesto/session_state.ex
+++ b/lib/attesto/session_state.ex
@@ -95,6 +95,21 @@ defmodule Attesto.SessionState do
   appended only when it is not the scheme's default — exactly the string the
   browser reports as `MessageEvent.origin` for a page loaded from `uri`.
 
+  The value must match the browser's WHATWG serialization byte-for-byte, or the
+  iframe recomputation compares unequal and the OP answers a permanent, false
+  `changed`. `URI.parse/1` (RFC 3986) diverges from the browser in two ways that
+  this corrects:
+
+    * **case** — the browser lowercases the scheme and host; `URI.parse/1`
+      preserves them (`https://RP.Example`), so both are lowercased here.
+    * **IPv6** — the browser serializes an IPv6 host in brackets
+      (`https://[::1]`); `URI.parse/1` strips them (`host: "::1"`), so a literal
+      host (one containing `:`) is re-bracketed here.
+
+  A host is expected already in ASCII/punycode form (as a registered
+  `redirect_uri` is): full IDNA Unicode→punycode mapping is out of scope, so a
+  raw non-ASCII host would still diverge.
+
   Returns `{:ok, origin}` or `{:error, :invalid_uri}` for a URI with no
   scheme/host (a `session_state` computed over a malformed origin could never
   compare equal in the browser, so fail closed instead).
@@ -104,11 +119,20 @@ defmodule Attesto.SessionState do
     case URI.parse(uri) do
       %URI{scheme: scheme, host: host} = parsed
       when is_binary(scheme) and scheme != "" and is_binary(host) and host != "" ->
+        scheme = String.downcase(scheme)
+        host = host |> String.downcase() |> bracket_ipv6()
         {:ok, "#{scheme}://#{host}#{origin_port(scheme, parsed.port)}"}
 
       _ ->
         {:error, :invalid_uri}
     end
+  end
+
+  # An IPv6 literal (the only host form containing `:`) must be wrapped in
+  # brackets to match the browser's WHATWG origin; a DNS host never contains a
+  # colon, so this is unambiguous.
+  defp bracket_ipv6(host) do
+    if String.contains?(host, ":"), do: "[#{host}]", else: host
   end
 
   @doc "A fresh random salt for `compute/4` (unpadded URL-safe Base64, no spaces or dots)."

--- a/lib/attesto/session_state.ex
+++ b/lib/attesto/session_state.ex
@@ -68,6 +68,10 @@ defmodule Attesto.SessionState do
   `origin` must be a browser-form origin (`scheme://host[:port]`, default port
   omitted) — derive it from the response's `redirect_uri` with `origin/1`.
   `salt` defaults to a fresh `generate_salt/0`.
+
+  Raises `ArgumentError` if an explicit `salt` is empty or contains a space
+  (§2 forbids a space in `session_state`) or a `.` (the `hash "." salt`
+  delimiter). `generate_salt/0` always satisfies this.
   """
   @spec compute(String.t(), String.t(), String.t(), String.t()) :: String.t()
   def compute(client_id, origin, op_browser_state, salt \\ generate_salt())
@@ -95,10 +99,11 @@ defmodule Attesto.SessionState do
   appended only when it is not the scheme's default — exactly the string the
   browser reports as `MessageEvent.origin` for a page loaded from `uri`.
 
-  The value must match the browser's WHATWG serialization byte-for-byte, or the
-  iframe recomputation compares unequal and the OP answers a permanent, false
-  `changed`. `URI.parse/1` (RFC 3986) diverges from the browser in two ways that
-  this corrects:
+  The value must equal the browser's WHATWG `MessageEvent.origin`, or the iframe
+  recomputation compares unequal and the OP answers a permanent, false
+  `changed` (a fail-safe error - it over-reports change, never under-reports).
+  `URI.parse/1` (RFC 3986) diverges from the browser; this closes the two
+  divergences a registered `redirect_uri` realistically hits:
 
     * **case** — the browser lowercases the scheme and host; `URI.parse/1`
       preserves them (`https://RP.Example`), so both are lowercased here.
@@ -106,9 +111,16 @@ defmodule Attesto.SessionState do
       (`https://[::1]`); `URI.parse/1` strips them (`host: "::1"`), so a literal
       host (one containing `:`) is re-bracketed here.
 
-  A host is expected already in ASCII/punycode form (as a registered
-  `redirect_uri` is): full IDNA Unicode→punycode mapping is out of scope, so a
-  raw non-ASCII host would still diverge.
+  This is NOT a full WHATWG serializer. The input is expected to be an
+  already-validated, canonical HTTP(S) `redirect_uri`; noncanonical forms are
+  left as-is and would still diverge (each yielding only the fail-safe false
+  `changed`, never a security bypass):
+
+    * a non-canonical IPv6 spelling (`[0:0:0:0:0:0:0:1]` vs the browser's
+      compressed `[::1]`) or a non-dotted-decimal IPv4 (`0177.0.0.1`);
+    * a raw non-ASCII host — full IDNA Unicode→punycode mapping is out of scope
+      (a registered redirect_uri is already ASCII/punycode);
+    * a non-HTTP(S) scheme, whose browser origin is the opaque `null`.
 
   Returns `{:ok, origin}` or `{:error, :invalid_uri}` for a URI with no
   scheme/host (a `session_state` computed over a malformed origin could never
@@ -163,6 +175,10 @@ defmodule Attesto.SessionState do
   space or `.`-ambiguity in its parts (each part is base64url-no-pad), so it is
   a valid `op_browser_state` for `compute/4` and splits back cleanly in
   `browser_state_valid?/3`.
+
+  Raises `ArgumentError` if `secret` is shorter than 32 bytes — an enforced
+  key-length floor (RFC 2104 §3) for the HMAC that makes the value OP-owned.
+  `browser_state_valid?/3` enforces the same floor.
   """
   @spec mint_browser_state(binary(), binary()) :: String.t()
   def mint_browser_state(secret, login_binding) when is_binary(secret) and is_binary(login_binding) do
@@ -190,6 +206,9 @@ defmodule Attesto.SessionState do
   wrong bytes, take the same path. The segments come from an attacker-supplied
   string and are not length-validated first, so the time taken still varies
   with how much was submitted; see that module for the distinction.
+
+  Raises `ArgumentError` if `secret` is shorter than the 32-byte floor
+  `mint_browser_state/2` enforces (RFC 2104 §3).
   """
   @spec browser_state_valid?(binary(), binary(), binary()) :: boolean()
   def browser_state_valid?(secret, value, login_binding)
@@ -224,12 +243,14 @@ defmodule Attesto.SessionState do
     :hmac |> :crypto.mac(:sha256, secret, data) |> Base.url_encode64(padding: false)
   end
 
-  # HMAC-SHA256 accepts any key length, so an empty or short OP secret produces
-  # a MAC an attacker can recompute (`:crypto.mac(:hmac, :sha256, "", data)` is
-  # deterministic and needs no secret) - the browser state would no longer be
-  # OP-owned. RFC 2104 §3 recommends a key at least as long as the hash output
-  # (32 bytes for SHA-256). The secret is OP configuration, not attacker input,
-  # so a too-short one is a misconfiguration to surface loudly, not tolerate.
+  # HMAC-SHA256 accepts any key length, but the OP browser state is only
+  # OP-owned while the key is a real secret. An EMPTY key is the degenerate
+  # case - `:crypto.mac(:hmac, :sha256, "", data)` is deterministic and needs no
+  # secret, so anyone can forge a MAC. A short-but-random key is not itself
+  # recomputable, but RFC 2104 §3 still recommends a key at least as long as the
+  # hash output (32 bytes for SHA-256) for full strength. Enforce that as a
+  # key-length policy: the secret is OP configuration, not attacker input, so a
+  # key below the floor is a misconfiguration to surface loudly, not tolerate.
   @min_secret_bytes 32
   defp validate_secret!(secret) do
     if byte_size(secret) < @min_secret_bytes do

--- a/test/attesto/attack_class_regression_test.exs
+++ b/test/attesto/attack_class_regression_test.exs
@@ -1,0 +1,167 @@
+defmodule Attesto.AttackClassRegressionTest do
+  @moduledoc false
+  # Tripwires for recurring OAuth/OIDC attack classes: each test drives a
+  # specific attack against a security-critical, SILENTLY-failing control and
+  # asserts attesto rejects it. Public CVEs are cited only as the canonical
+  # example of a class - never to describe an unpatched bug anywhere.
+  #
+  # Attribution rule: cite only the governing RFC requirement or an ALREADY-
+  # PUBLIC CVE. Do not describe an unpatched or undisclosed vulnerability in any
+  # other project - this file is public, and a comment naming a peer's live bug
+  # would be a disclosure. The value here is protecting attesto's own controls,
+  # not cataloguing anyone else's.
+  #
+  # These are not tests of attesto features - they are tests that a control has
+  # not regressed into a weakened shape. Every one was verified to FAIL if the
+  # control is removed; a regression test that cannot fail is false confidence,
+  # not coverage. When adding one, revert the guard once to watch it go red.
+  use ExUnit.Case, async: true
+
+  alias Attesto.AuthorizationRequest
+  alias Attesto.DPoP
+  alias Attesto.RedirectURI
+  alias Attesto.RequestObject
+  alias Attesto.Test.Factory
+
+  @registered ["https://app.example.com/cb"]
+
+  describe "open redirect via error emitted before redirect_uri validation" do
+    # Authlib CVE-2026-41479: an unsupported response_type with an
+    # attacker-controlled redirect_uri turned the authorization endpoint into an
+    # unauthenticated open redirect, because the error was produced BEFORE the
+    # redirect_uri was validated against the client. attesto establishes the
+    # redirect target first, so an unregistered URI is a DIRECT (non-redirected)
+    # error under every failure it could otherwise ride out on.
+    test "an unsupported response_type with an unregistered redirect_uri is a direct error" do
+      result =
+        AuthorizationRequest.validate(
+          %{
+            "client_id" => "c1",
+            "response_type" => "token",
+            "redirect_uri" => "https://evil.example/cb",
+            "scope" => "openid",
+            "state" => "s"
+          },
+          registered_redirect_uris: @registered,
+          require_pkce: false
+        )
+
+      assert match?({:error, {:direct, _}}, result),
+             "an error must not be redirected to an unregistered redirect_uri (Authlib CVE-2026-41479 class)"
+    end
+
+    # Same class via an invalid scope rather than response_type.
+    test "an invalid scope with an unregistered redirect_uri is a direct error" do
+      result =
+        AuthorizationRequest.validate(
+          %{
+            "client_id" => "c1",
+            "response_type" => "code",
+            "redirect_uri" => "https://evil.example/cb",
+            "scope" => "nope",
+            "state" => "s"
+          },
+          registered_redirect_uris: @registered,
+          require_pkce: false
+        )
+
+      assert match?({:error, {:direct, _}}, result)
+    end
+  end
+
+  describe "redirect_uri validation bypass via crafted authority" do
+    # Keycloak CVE-2026-7504: an `@` in the authority (userinfo) bypassed
+    # redirect validation - `https://app.example.com@evil.example/cb` has host
+    # `evil.example`, not `app.example.com`. attesto matches byte-exactly (no
+    # wildcards, so it never matches the registered URI) AND unambiguous?/1
+    # refuses userinfo outright, so it can never enter a registered set either.
+    test "an @-authority (userinfo) redirect_uri is neither a match nor admissible" do
+      crafted = "https://app.example.com@evil.example/cb"
+      refute RedirectURI.registered?(crafted, @registered, :exact)
+      refute RedirectURI.unambiguous?(crafted)
+    end
+
+    # An `@` in the PATH (not the authority) is legitimate and must stay
+    # admissible - guards the assertion above against over-rejecting.
+    test "an @ in the path is still admissible" do
+      assert RedirectURI.unambiguous?("https://app.example.com/@handle/cb")
+    end
+
+    # Keycloak CVE-2026-3872: `..;/` path traversal bypassed validation.
+    # Byte-exact matching has no normalization to exploit.
+    test "a ..;/ path-traversal redirect_uri does not match a registered one" do
+      refute RedirectURI.registered?("https://app.example.com/..;/cb", @registered, :exact)
+    end
+
+    # The parser-differential class attesto fixed in 1.5.0 (RFC 3986 vs WHATWG):
+    # a backslash-userinfo authority two parsers read differently.
+    test "a parser-ambiguous backslash-userinfo redirect_uri is inadmissible" do
+      refute RedirectURI.unambiguous?("https://evil.example\\@app.example.com/cb")
+    end
+  end
+
+  describe "DPoP proof is signature-verified with alg constrained" do
+    # RFC 9449 §4.3: a DPoP proof MUST be a JWS verified against the key in its
+    # own header, and §4.2 restricts the algorithm to asymmetric. attesto
+    # verifies the signature and whitelists asymmetric algs, so alg:none (and
+    # symmetric algs) are refused rather than trusted.
+    test "a proof with alg:none is refused" do
+      # Build a syntactically shaped proof claiming alg:none.
+      header = Base.url_encode64(JSON.encode!(%{"typ" => "dpop+jwt", "alg" => "none", "jwk" => %{}}), padding: false)
+      payload = Base.url_encode64(JSON.encode!(%{"htm" => "GET", "htu" => "https://api.example.com/x"}), padding: false)
+      none_proof = header <> "." <> payload <> "."
+
+      assert {:error, _} =
+               DPoP.verify_proof(none_proof, http_method: "GET", http_uri: "https://api.example.com/x")
+    end
+
+    test "a well-formed proof verifies (guards against a vacuous refusal above)" do
+      {proof, _jkt} = Factory.dpop_proof(htm: "GET", htu: "https://api.example.com/x")
+
+      assert {:ok, _} =
+               DPoP.verify_proof(proof, http_method: "GET", http_uri: "https://api.example.com/x")
+    end
+  end
+
+  describe "request object (JAR) is signature-verified" do
+    # RFC 9101 §6.3: the authorization server MUST validate the signature of a
+    # request object against the client's registered keys. Decoding its claims
+    # without verifying the signature (a "peek") would let an attacker forge
+    # authorization parameters. attesto verifies against the client's trusted
+    # JWKS and constrains the algorithm, so alg:none and unknown-key request
+    # objects are refused.
+    setup do
+      jwk = JOSE.JWK.generate_key({:ec, "P-256"})
+      {_, pub} = JOSE.JWK.to_public_map(jwk)
+      %{jwk: jwk, trusted: %{"keys" => [pub]}}
+    end
+
+    test "an alg:none request object is refused", %{trusted: trusted} do
+      header = Base.url_encode64(JSON.encode!(%{"alg" => "none"}), padding: false)
+
+      payload =
+        Base.url_encode64(JSON.encode!(%{"client_id" => "c1", "scope" => "admin", "iss" => "c1"}), padding: false)
+
+      none = header <> "." <> payload <> "."
+
+      assert {:error, _} = RequestObject.verify(none, trusted)
+    end
+
+    test "a request object signed by a key the server does not trust is refused", %{trusted: trusted} do
+      attacker = JOSE.JWK.generate_key({:ec, "P-256"})
+      now = System.system_time(:second)
+
+      {_, forged} =
+        attacker
+        |> JOSE.JWT.sign(%{"alg" => "ES256"}, %{
+          "client_id" => "c1",
+          "scope" => "admin",
+          "iss" => "c1",
+          "exp" => now + 300
+        })
+        |> JOSE.JWS.compact()
+
+      assert {:error, :invalid_signature} = RequestObject.verify(forged, trusted)
+    end
+  end
+end

--- a/test/attesto/ciba_request_test.exs
+++ b/test/attesto/ciba_request_test.exs
@@ -294,6 +294,26 @@ defmodule Attesto.CIBA.RequestTest do
                Request.validate(signing_client(key), %{"request" => jwt}, signed_opts())
     end
 
+    test "the generic JWT media type is accepted with or without the application/ prefix" do
+      # RFC 7515 §4.1.9: `JWT` and `application/jwt` are the same media type.
+      key = ec_key()
+
+      for typ <- ["JWT", "application/jwt", "application/JWT"] do
+        jwt = signed_request(key, %{}, %{"typ" => typ})
+
+        assert {:ok, %Request{}} =
+                 Request.validate(signing_client(key), %{"request" => jwt}, signed_opts())
+      end
+    end
+
+    test "cross-context typing is rejected in its application/-prefixed spelling too" do
+      key = ec_key()
+      jwt = signed_request(key, %{}, %{"typ" => "application/oauth-authz-req+jwt"})
+
+      assert {:error, :invalid_request} =
+               Request.validate(signing_client(key), %{"request" => jwt}, signed_opts())
+    end
+
     test "alg confusion: an RS256-signed request is rejected by the FAPI default allowlist" do
       key = JOSE.JWK.generate_key({:rsa, 2048})
       jwt = signed_request(key, %{}, %{"alg" => "RS256", "kid" => JOSE.JWK.thumbprint(key)})

--- a/test/attesto/ciba_request_test.exs
+++ b/test/attesto/ciba_request_test.exs
@@ -281,6 +281,19 @@ defmodule Attesto.CIBA.RequestTest do
                Request.validate(signing_client(key), %{"request" => jwt}, signed_opts())
     end
 
+    test "cross-context typing: a request typed as an authorization-endpoint JAR is rejected" do
+      # RFC 9101 §10.8 explicit typing. A CIBA signed request and an authorize
+      # JAR share `aud` (this issuer) and `iss` (the client), so a JAR carrying
+      # `typ: oauth-authz-req+jwt` otherwise satisfies every CIBA claim check.
+      # CIBA §7.1.1 defines no typ, so it must not be honoured as a backchannel
+      # authentication request.
+      key = ec_key()
+      jwt = signed_request(key, %{}, %{"typ" => "oauth-authz-req+jwt"})
+
+      assert {:error, :invalid_request} =
+               Request.validate(signing_client(key), %{"request" => jwt}, signed_opts())
+    end
+
     test "alg confusion: an RS256-signed request is rejected by the FAPI default allowlist" do
       key = JOSE.JWK.generate_key({:rsa, 2048})
       jwt = signed_request(key, %{}, %{"alg" => "RS256", "kid" => JOSE.JWK.thumbprint(key)})

--- a/test/attesto/dpop_corpus_test.exs
+++ b/test/attesto/dpop_corpus_test.exs
@@ -407,11 +407,11 @@ defmodule Attesto.DPoPCorpusTest do
     test ":replay fires only after every other gate passes (clean proof reaches it)" do
       # This is the case the sibling suites under-cover: a fully valid proof
       # that fails ONLY at the replay gate, with the check observing the
-      # namespaced replay key (jkt:jti) and the acceptance-window ttl plus 1s
-      # retention margin (default max_age 60 + skew 60 + 1 = 121).
+      # namespaced replay key (a digest of jkt:jti) and the acceptance-window
+      # ttl plus 1s retention margin (default max_age 60 + skew 60 + 1 = 121).
       jti = "corpus-replay-#{System.unique_integer([:positive])}"
       {proof, jkt} = Factory.dpop_proof(jti: jti, iat: @now)
-      replay_key = jkt <> ":" <> jti
+      replay_key = :sha256 |> :crypto.hash(jkt <> ":" <> jti) |> Base.url_encode64(padding: false)
       parent = self()
 
       replay_check = fn seen, ttl ->

--- a/test/attesto/dpop_corpus_test.exs
+++ b/test/attesto/dpop_corpus_test.exs
@@ -407,7 +407,8 @@ defmodule Attesto.DPoPCorpusTest do
     test ":replay fires only after every other gate passes (clean proof reaches it)" do
       # This is the case the sibling suites under-cover: a fully valid proof
       # that fails ONLY at the replay gate, with the check observing the jti
-      # and the acceptance-window ttl (default max_age 60 + skew 60 = 120).
+      # and the acceptance-window ttl plus 1s retention margin
+      # (default max_age 60 + skew 60 + 1 = 121).
       jti = "corpus-replay-#{System.unique_integer([:positive])}"
       {proof, _jkt} = Factory.dpop_proof(jti: jti, iat: @now)
       parent = self()
@@ -418,7 +419,7 @@ defmodule Attesto.DPoPCorpusTest do
       end
 
       assert {:error, :replay} = DPoP.verify_proof(proof, opts(replay_check: replay_check))
-      assert_received {:replay_seen, ^jti, 120}
+      assert_received {:replay_seen, ^jti, 121}
     end
 
     test ":replay_check is NOT consulted when an earlier gate (htm) already fails" do

--- a/test/attesto/dpop_corpus_test.exs
+++ b/test/attesto/dpop_corpus_test.exs
@@ -406,11 +406,12 @@ defmodule Attesto.DPoPCorpusTest do
 
     test ":replay fires only after every other gate passes (clean proof reaches it)" do
       # This is the case the sibling suites under-cover: a fully valid proof
-      # that fails ONLY at the replay gate, with the check observing the jti
-      # and the acceptance-window ttl plus 1s retention margin
-      # (default max_age 60 + skew 60 + 1 = 121).
+      # that fails ONLY at the replay gate, with the check observing the
+      # namespaced replay key (jkt:jti) and the acceptance-window ttl plus 1s
+      # retention margin (default max_age 60 + skew 60 + 1 = 121).
       jti = "corpus-replay-#{System.unique_integer([:positive])}"
-      {proof, _jkt} = Factory.dpop_proof(jti: jti, iat: @now)
+      {proof, jkt} = Factory.dpop_proof(jti: jti, iat: @now)
+      replay_key = jkt <> ":" <> jti
       parent = self()
 
       replay_check = fn seen, ttl ->
@@ -419,7 +420,7 @@ defmodule Attesto.DPoPCorpusTest do
       end
 
       assert {:error, :replay} = DPoP.verify_proof(proof, opts(replay_check: replay_check))
-      assert_received {:replay_seen, ^jti, 121}
+      assert_received {:replay_seen, ^replay_key, 121}
     end
 
     test ":replay_check is NOT consulted when an earlier gate (htm) already fails" do

--- a/test/attesto/dpop_test.exs
+++ b/test/attesto/dpop_test.exs
@@ -765,9 +765,10 @@ defmodule Attesto.DPoPTest do
       assert {:ok, %{jti: ^jti}} =
                DPoP.verify_proof(proof, base_opts(replay_check: replay_check))
 
-      # The verifier passes the acceptance window (default max_age 60 +
+      # The verifier passes the acceptance window + 1s of retention margin
+      # (default max_age 60 +
       # future skew 60) as the TTL the cache must remember the jti for.
-      assert_received {:replay_check_called, ^jti, 120}
+      assert_received {:replay_check_called, ^jti, 121}
       # Exactly once.
       refute_received {:replay_check_called, _, _}
     end
@@ -780,7 +781,7 @@ defmodule Attesto.DPoPTest do
       assert {:ok, _} =
                DPoP.verify_proof(proof, base_opts(max_age_seconds: 300, replay_check: replay_check))
 
-      assert_received {:ttl, 360}
+      assert_received {:ttl, 361}
     end
 
     test "rejects the request when :replay_check returns {:error, :replay}" do

--- a/test/attesto/dpop_test.exs
+++ b/test/attesto/dpop_test.exs
@@ -755,9 +755,9 @@ defmodule Attesto.DPoPTest do
     test "calls :replay_check exactly once on the happy path with the namespaced replay key and a ttl" do
       jti = "jti-#{System.unique_integer([:positive])}"
       {proof, jkt} = Factory.dpop_proof(jti: jti)
-      # The replay identity is the jti NAMESPACED by the proof key (jkt:jti), so
-      # one key's proof cannot evict another's from the cache.
-      replay_key = jkt <> ":" <> jti
+      # The replay identity is a fixed-length digest of the jti NAMESPACED by the
+      # proof key, so one key's proof cannot evict another's from the cache.
+      replay_key = :sha256 |> :crypto.hash(jkt <> ":" <> jti) |> Base.url_encode64(padding: false)
       parent = self()
 
       replay_check = fn seen, ttl ->
@@ -805,6 +805,7 @@ defmodule Attesto.DPoPTest do
       {proof_b, jkt_b} = Factory.dpop_proof(jti: jti)
       assert jkt_a != jkt_b
 
+      digest = fn jkt -> :sha256 |> :crypto.hash(jkt <> ":" <> jti) |> Base.url_encode64(padding: false) end
       seen = fn key, _ttl -> send(self(), {:key, key}) && :ok end
 
       assert {:ok, %{replay_key: key_a}} =
@@ -813,9 +814,12 @@ defmodule Attesto.DPoPTest do
       assert {:ok, %{replay_key: key_b}} =
                DPoP.verify_proof(proof_b, base_opts(replay_check: seen))
 
-      assert key_a == jkt_a <> ":" <> jti
-      assert key_b == jkt_b <> ":" <> jti
+      # Fixed-length (43-char base64url) digests, distinct per key, so no
+      # cross-key collision in the replay store.
+      assert key_a == digest.(jkt_a)
+      assert key_b == digest.(jkt_b)
       assert key_a != key_b
+      assert byte_size(key_a) == 43
     end
 
     test ":replay_check is NOT consulted when an earlier check would fail" do

--- a/test/attesto/dpop_test.exs
+++ b/test/attesto/dpop_test.exs
@@ -752,9 +752,12 @@ defmodule Attesto.DPoPTest do
   # -----------------------------------------------------------------
 
   describe "verify_proof/2 replay protection (:replay_check)" do
-    test "calls :replay_check exactly once on the happy path with the proof's jti and a ttl" do
+    test "calls :replay_check exactly once on the happy path with the namespaced replay key and a ttl" do
       jti = "jti-#{System.unique_integer([:positive])}"
-      {proof, _jkt} = Factory.dpop_proof(jti: jti)
+      {proof, jkt} = Factory.dpop_proof(jti: jti)
+      # The replay identity is the jti NAMESPACED by the proof key (jkt:jti), so
+      # one key's proof cannot evict another's from the cache.
+      replay_key = jkt <> ":" <> jti
       parent = self()
 
       replay_check = fn seen, ttl ->
@@ -762,13 +765,13 @@ defmodule Attesto.DPoPTest do
         :ok
       end
 
-      assert {:ok, %{jti: ^jti}} =
+      assert {:ok, %{jti: ^jti, replay_key: ^replay_key}} =
                DPoP.verify_proof(proof, base_opts(replay_check: replay_check))
 
       # The verifier passes the acceptance window + 1s of retention margin
       # (default max_age 60 +
-      # future skew 60) as the TTL the cache must remember the jti for.
-      assert_received {:replay_check_called, ^jti, 121}
+      # future skew 60) as the TTL the cache must remember the key for.
+      assert_received {:replay_check_called, ^replay_key, 121}
       # Exactly once.
       refute_received {:replay_check_called, _, _}
     end
@@ -790,6 +793,29 @@ defmodule Attesto.DPoPTest do
 
       assert {:error, :replay} =
                DPoP.verify_proof(proof, base_opts(replay_check: replay_check))
+    end
+
+    test "two different keys reusing the same jti get distinct replay keys (no cross-key collision)" do
+      # jti uniqueness is only guaranteed per key (RFC 9449 §4.2). Two proofs
+      # that share a jti but are signed by different keys must present DIFFERENT
+      # replay identities, so recording one cannot falsely evict the other - and
+      # so an attacker cannot pre-burn a victim's jti under the attacker's key.
+      jti = "shared-#{System.unique_integer([:positive])}"
+      {proof_a, jkt_a} = Factory.dpop_proof(jti: jti)
+      {proof_b, jkt_b} = Factory.dpop_proof(jti: jti)
+      assert jkt_a != jkt_b
+
+      seen = fn key, _ttl -> send(self(), {:key, key}) && :ok end
+
+      assert {:ok, %{replay_key: key_a}} =
+               DPoP.verify_proof(proof_a, base_opts(replay_check: seen))
+
+      assert {:ok, %{replay_key: key_b}} =
+               DPoP.verify_proof(proof_b, base_opts(replay_check: seen))
+
+      assert key_a == jkt_a <> ":" <> jti
+      assert key_b == jkt_b <> ":" <> jti
+      assert key_a != key_b
     end
 
     test ":replay_check is NOT consulted when an earlier check would fail" do

--- a/test/attesto/identity_assertion_test.exs
+++ b/test/attesto/identity_assertion_test.exs
@@ -211,6 +211,17 @@ defmodule Attesto.IdentityAssertionTest do
                IdentityAssertion.verify(jwt, public_jwks(key, "RS256"), opts())
     end
 
+    test "rejects a present non-integer nbf rather than treating it as absent" do
+      # A malformed `nbf` (string, not a NumericDate) must fail closed. If it
+      # fell through to the not-present clause, a garbage `nbf` would bypass the
+      # not-yet-valid check entirely.
+      key = rsa_key()
+      jwt = assertion(key, "RS256", %{"nbf" => "soon"})
+
+      assert {:error, :invalid_claims} =
+               IdentityAssertion.verify(jwt, public_jwks(key, "RS256"), opts())
+    end
+
     test "rejects an assertion exceeding max_lifetime_seconds" do
       key = rsa_key()
       now = System.system_time(:second)

--- a/test/attesto/jarm_test.exs
+++ b/test/attesto/jarm_test.exs
@@ -94,6 +94,19 @@ defmodule Attesto.JARMTest do
     assert occurrences(payload, ~s("exp")) == 1
   end
 
+  test "a non-string, non-atom key that would forge a duplicate claim is rejected", %{
+    config: config
+  } do
+    # A charlist key JSON-encodes to the same member name as a string key, so it
+    # could shadow a reserved claim as a duplicate member. The contract is
+    # string keys; a violation must raise, not silently emit a duplicate.
+    for forged <- [%{~c"iss" => "https://evil.example"}, %{~c"aud" => "attacker"}] do
+      assert_raise ArgumentError, fn ->
+        JARM.response_jwt(config, "client-123", forged)
+      end
+    end
+  end
+
   test "signs an error response (no code), addressed to the client", %{config: config} do
     {:ok, jwt} =
       JARM.response_jwt(config, "client-123", %{

--- a/test/attesto/jarm_test.exs
+++ b/test/attesto/jarm_test.exs
@@ -30,6 +30,15 @@ defmodule Attesto.JARMTest do
     jwt |> JOSE.JWS.peek_protected() |> JSON.decode!()
   end
 
+  # The raw signed payload, before JSON decoding - so a test can assert on the
+  # wire bytes (e.g. that a claim name appears exactly once).
+  defp raw_payload(jwt) do
+    [_header, payload, _sig] = String.split(jwt, ".")
+    Base.url_decode64!(payload, padding: false)
+  end
+
+  defp occurrences(haystack, needle), do: length(String.split(haystack, needle)) - 1
+
   test "signs a success response with iss/aud/exp/iat and the response params", %{config: config} do
     now = 1_700_000_000
 
@@ -51,6 +60,38 @@ defmodule Attesto.JARMTest do
     # The authorization-response parameters ride as top-level claims.
     assert claims["code"] == "abc"
     assert claims["state"] == "xyz"
+  end
+
+  test "reserved claims stay server-authoritative when a caller mixes in atom keys", %{
+    config: config
+  } do
+    now = 1_700_000_000
+
+    {:ok, jwt} =
+      JARM.response_jwt(
+        config,
+        "client-123",
+        # An atom-keyed reserved claim is a distinct map key from the server's
+        # string "iss"; without key normalization both would serialize to the
+        # same JSON member and a lenient client parser could read the caller's.
+        %{:iss => "https://evil.example", :aud => "attacker", :exp => 1, "code" => "abc"},
+        now: now
+      )
+
+    claims = verify(config, jwt)
+
+    # The server's values win, and the caller's atom-keyed shadows are gone.
+    assert claims["iss"] == config.issuer
+    assert claims["aud"] == "client-123"
+    assert claims["exp"] == now + 600
+    assert claims["code"] == "abc"
+
+    # Each reserved claim appears exactly once on the wire - no duplicate JSON
+    # member for a lenient parser to disagree with the verifier over.
+    payload = raw_payload(jwt)
+    assert occurrences(payload, ~s("iss")) == 1
+    assert occurrences(payload, ~s("aud")) == 1
+    assert occurrences(payload, ~s("exp")) == 1
   end
 
   test "signs an error response (no code), addressed to the client", %{config: config} do

--- a/test/attesto/request_object_test.exs
+++ b/test/attesto/request_object_test.exs
@@ -563,6 +563,32 @@ defmodule Attesto.RequestObjectTest do
     end
   end
 
+  describe "parameter coercion is total (never raises)" do
+    test "an extension claim that is an array with a non-string member is dropped, not raised on" do
+      # Under the default JAR path (no `:string_valued_claims` constraint) an
+      # arbitrary passthrough claim reaches `claims_to_params/1`. A list member
+      # that is not a binary must make the whole claim drop out - never reach
+      # `Enum.join/2`, which raises `Protocol.UndefinedError` on a non-string.
+      # A registered client with a valid signing key could otherwise crash the
+      # auth-request process at will.
+      key = ec_key()
+      jwt = request_object(key, %{"ext_list" => ["ok", %{"nested" => 1}]})
+
+      assert {:ok, params} =
+               RequestObject.verify(jwt, %{"keys" => [public_jwk(key)]}, base_opts())
+
+      refute Map.has_key?(params, "ext_list")
+    end
+
+    test "an all-string extension array is still joined into a space-delimited param" do
+      key = ec_key()
+      jwt = request_object(key, %{"ext_list" => ["a", "b"]})
+
+      assert {:ok, %{"ext_list" => "a b"}} =
+               RequestObject.verify(jwt, %{"keys" => [public_jwk(key)]}, base_opts())
+    end
+  end
+
   describe "forbidden nested request parameters (RFC 9101 §4)" do
     test "rejects a request object that carries a nested request claim" do
       key = ec_key()

--- a/test/attesto/request_object_test.exs
+++ b/test/attesto/request_object_test.exs
@@ -517,6 +517,34 @@ defmodule Attesto.RequestObjectTest do
                )
     end
 
+    test "accepted_typ treats a bare subtype and its application/ form as equal" do
+      # RFC 7515 §4.1.9: the `application/` prefix may be omitted for a bare
+      # subtype, so `application/oauth-authz-req+jwt` == `oauth-authz-req+jwt`.
+      key = ec_key()
+      jwt = request_object(key, %{}, %{"typ" => "application/oauth-authz-req+jwt"})
+
+      assert {:ok, _} =
+               RequestObject.verify(
+                 jwt,
+                 %{"keys" => [public_jwk(key)]},
+                 base_opts() ++ [accepted_typ: ["oauth-authz-req+jwt"]]
+               )
+    end
+
+    test "accepted_typ does NOT collapse a multi-slash value onto its application/-stripped form" do
+      # The prefix convention is only for a bare subtype (no further `/`).
+      # `application/text/example` must NOT be treated as `text/example`.
+      key = ec_key()
+      jwt = request_object(key, %{}, %{"typ" => "application/text/example"})
+
+      assert {:error, :invalid_typ} =
+               RequestObject.verify(
+                 jwt,
+                 %{"keys" => [public_jwk(key)]},
+                 base_opts() ++ [accepted_typ: ["text/example"]]
+               )
+    end
+
     test "accepted_typ rejects an absent typ unless nil is a member" do
       key = ec_key()
       jwt = request_object_without_typ(key)

--- a/test/attesto/scope_test.exs
+++ b/test/attesto/scope_test.exs
@@ -336,4 +336,73 @@ defmodule Attesto.ScopeTest do
       assert Scope.unknown(catalog, ["bad1", "documents.read", "bad2"]) == ["bad1", "bad2"]
     end
   end
+
+  describe "grants_all?/3 — indexed form equivalence and complexity" do
+    setup do
+      %{catalog: Scope.new_catalog(Enum.map(1..200, &"res#{&1}.read") ++ Enum.map(1..200, &"res#{&1}.write"))}
+    end
+
+    # The indexed grants_all?/3 must agree with the naive per-required
+    # Enum.all?(grants?/3) form on every input. Cover exact, resource-wildcard,
+    # full-wildcard, unknown, and mixed granted sets.
+    test "agrees with the naive Enum.all?(grants?) form", %{catalog: catalog} do
+      naive = fn granted, required -> Enum.all?(required, &Scope.grants?(catalog, granted, &1)) end
+
+      granted_sets = [
+        ["res1.read", "res2.read"],
+        ["res1.*"],
+        ["*"],
+        ["res1.*", "res2.write", "res3.read"],
+        ["res1.read", "nonsense", "res5.*", "*"],
+        [],
+        ["res1.read", 123, nil, "res2.*"]
+      ]
+
+      required_sets = [
+        ["res1.read"],
+        ["res1.read", "res1.write"],
+        ["res2.read", "res3.read"],
+        ["res1.read", "res200.write"],
+        ["uncatalogued.read"],
+        ["res1.*"],
+        ["res1.read", "res2.read", "res5.write"]
+      ]
+
+      for granted <- granted_sets, required <- required_sets, required != [] do
+        assert Scope.grants_all?(catalog, granted, required) == naive.(granted, required),
+               "mismatch: granted=#{inspect(granted)} required=#{inspect(required)}"
+      end
+    end
+
+    # The bug this replaced: a large caller-supplied required list is a DoS
+    # lever. Indexed form is O(|granted| + |required|), so 500k required
+    # scopes must stay well under a second - and 10x the input stays ~10x the
+    # time, not ~100x.
+    @tag :timing
+    test "stays linear as the required list grows", %{catalog: catalog} do
+      granted = Enum.map(1..200, &"res#{&1}.read")
+      # Build the inputs OUTSIDE the timer: constructing a 500k-element list of
+      # interpolated strings is itself superlinear in wall-clock (GC), and timing
+      # it alongside the call is what made an earlier measurement look
+      # superlinear when the function is not.
+      r_50k = Enum.map(1..50_000, fn i -> "res#{rem(i, 200) + 1}.read" end)
+      r_500k = Enum.map(1..500_000, fn i -> "res#{rem(i, 200) + 1}.read" end)
+
+      # Warm the module so the first call does not pay load cost.
+      Scope.grants_all?(catalog, granted, r_50k)
+
+      {us_50k, true} = :timer.tc(fn -> Scope.grants_all?(catalog, granted, r_50k) end)
+      {us_500k, true} = :timer.tc(fn -> Scope.grants_all?(catalog, granted, r_500k) end)
+
+      # Absolute bound: the pre-fix code took ~20s at 500k; linear is ~40ms.
+      # 500ms is a wide margin that still catches a regression to superlinear.
+      assert us_500k < 500_000, "500k scopes took #{Float.round(us_500k / 1000, 1)}ms; expected < 500ms"
+
+      # 10x the input must give ~10x the time, not the ~20x the superlinear
+      # scan showed. 15x leaves headroom for noise while still failing on a
+      # return to quadratic-ish behaviour.
+      ratio = us_500k / max(us_50k, 1)
+      assert ratio < 15, "10x input gave #{Float.round(ratio, 1)}x time; expected ~linear (<15x)"
+    end
+  end
 end

--- a/test/attesto/scope_test.exs
+++ b/test/attesto/scope_test.exs
@@ -1,6 +1,7 @@
 defmodule Attesto.ScopeTest do
   @moduledoc false
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
   alias Attesto.Scope
 
@@ -342,35 +343,47 @@ defmodule Attesto.ScopeTest do
       %{catalog: Scope.new_catalog(Enum.map(1..200, &"res#{&1}.read") ++ Enum.map(1..200, &"res#{&1}.write"))}
     end
 
-    # The indexed grants_all?/3 must agree with the naive per-required
-    # Enum.all?(grants?/3) form on every input. Cover exact, resource-wildcard,
-    # full-wildcard, unknown, and mixed granted sets.
-    test "agrees with the naive Enum.all?(grants?) form", %{catalog: catalog} do
+    # Exercise arbitrary proper lists, including catalogs that contain entries
+    # which also parse as grant wildcards. This is a generated property rather
+    # than a fixed table so interactions among catalog membership, wildcard
+    # classification, duplicate/empty values, and non-binary members are covered.
+    property "agrees with the naive Enum.all?(grants?) form" do
+      catalog_values = ["res.read", "res.write", "res.*", "other.read", "unknown.*", "*", "", <<255>>]
+      input_values = catalog_values ++ ["res.read.*", ".*", "*.read", nil, 123, :scope]
+
+      check all(
+              catalog_entries <- list_of(member_of(catalog_values), max_length: 8),
+              granted <- list_of(member_of(input_values), max_length: 12),
+              required <- list_of(member_of(input_values), min_length: 1, max_length: 8),
+              max_runs: 500
+            ) do
+        catalog = Scope.new_catalog(catalog_entries)
+        naive = Enum.all?(required, &Scope.grants?(catalog, granted, &1))
+
+        assert Scope.grants_all?(catalog, granted, required) == naive,
+               "mismatch: catalog=#{inspect(catalog_entries)} granted=#{inspect(granted)} " <>
+                 "required=#{inspect(required)}"
+      end
+    end
+
+    test "agrees on wildcard/catalog ambiguities and malformed grant members" do
+      catalog = Scope.new_catalog(["res.read", "res.*", "other.read"])
       naive = fn granted, required -> Enum.all?(required, &Scope.grants?(catalog, granted, &1)) end
 
-      granted_sets = [
-        ["res1.read", "res2.read"],
-        ["res1.*"],
-        ["*"],
-        ["res1.*", "res2.write", "res3.read"],
-        ["res1.read", "nonsense", "res5.*", "*"],
-        [],
-        ["res1.read", 123, nil, "res2.*"]
+      cases = [
+        # This entry is both exact-known and parsed as a resource wildcard. Both
+        # implementations must give wildcard parsing precedence.
+        {["res.*"], ["res.*", "res.read"]},
+        # An unknown resource wildcard follows the exact fallback but cannot
+        # grant a known scope under another resource.
+        {["ghost.*"], ["res.read"]},
+        # Duplicates, empty strings, and non-binaries do not alter the
+        # existential grant result.
+        {["", nil, 123, "res.read", "res.read"], ["res.read"]}
       ]
 
-      required_sets = [
-        ["res1.read"],
-        ["res1.read", "res1.write"],
-        ["res2.read", "res3.read"],
-        ["res1.read", "res200.write"],
-        ["uncatalogued.read"],
-        ["res1.*"],
-        ["res1.read", "res2.read", "res5.write"]
-      ]
-
-      for granted <- granted_sets, required <- required_sets, required != [] do
-        assert Scope.grants_all?(catalog, granted, required) == naive.(granted, required),
-               "mismatch: granted=#{inspect(granted)} required=#{inspect(required)}"
+      for {granted, required} <- cases do
+        assert Scope.grants_all?(catalog, granted, required) == naive.(granted, required)
       end
     end
 
@@ -379,30 +392,33 @@ defmodule Attesto.ScopeTest do
     # scopes must stay well under a second - and 10x the input stays ~10x the
     # time, not ~100x.
     @tag :timing
-    test "stays linear as the required list grows", %{catalog: catalog} do
-      granted = Enum.map(1..200, &"res#{&1}.read")
-      # Build the inputs OUTSIDE the timer: constructing a 500k-element list of
-      # interpolated strings is itself superlinear in wall-clock (GC), and timing
-      # it alongside the call is what made an earlier measurement look
-      # superlinear when the function is not.
-      r_50k = Enum.map(1..50_000, fn i -> "res#{rem(i, 200) + 1}.read" end)
-      r_500k = Enum.map(1..500_000, fn i -> "res#{rem(i, 200) + 1}.read" end)
+    test "stays linear when BOTH granted and required grow (pins the cross-product removal)" do
+      # The earlier version held `granted` at 200 and only grew `required`. That
+      # cannot distinguish the fix: the old O(required x granted) form is also
+      # ~linear when only `required` grows. The cross-product blowup appears
+      # only when BOTH axes grow together, so scale both, and make every
+      # required scope match (required == granted) so the old `Enum.all?` never
+      # short-circuits and each `Enum.any?` scans deep - the true worst case.
+      build = fn n ->
+        scopes = Enum.map(1..n, &"res#{&1}.read")
+        {Scope.new_catalog(scopes), scopes, scopes}
+      end
 
-      # Warm the module so the first call does not pay load cost.
-      Scope.grants_all?(catalog, granted, r_50k)
+      {cat_a, g_a, r_a} = build.(4_000)
+      {cat_b, g_b, r_b} = build.(16_000)
 
-      {us_50k, true} = :timer.tc(fn -> Scope.grants_all?(catalog, granted, r_50k) end)
-      {us_500k, true} = :timer.tc(fn -> Scope.grants_all?(catalog, granted, r_500k) end)
+      Scope.grants_all?(cat_a, g_a, r_a)
 
-      # Absolute bound: the pre-fix code took ~20s at 500k; linear is ~40ms.
-      # 500ms is a wide margin that still catches a regression to superlinear.
-      assert us_500k < 500_000, "500k scopes took #{Float.round(us_500k / 1000, 1)}ms; expected < 500ms"
+      {us_a, true} = :timer.tc(fn -> Scope.grants_all?(cat_a, g_a, r_a) end)
+      {us_b, true} = :timer.tc(fn -> Scope.grants_all?(cat_b, g_b, r_b) end)
 
-      # 10x the input must give ~10x the time, not the ~20x the superlinear
-      # scan showed. 15x leaves headroom for noise while still failing on a
-      # return to quadratic-ish behaviour.
-      ratio = us_500k / max(us_50k, 1)
-      assert ratio < 15, "10x input gave #{Float.round(ratio, 1)}x time; expected ~linear (<15x)"
+      # 4x on both axes is 16x work for the cross-product, ~4x for linear.
+      # Absolute: 16k x 16k = 256M naive ops would be seconds; linear is ~ms.
+      assert us_b < 500_000,
+             "16k x 16k took #{Float.round(us_b / 1000, 1)}ms; expected < 500ms (naive would be seconds)"
+
+      ratio = us_b / max(us_a, 1)
+      assert ratio < 8, "4x on both axes gave #{Float.round(ratio, 1)}x time; linear is ~4x, cross-product ~16x"
     end
   end
 end

--- a/test/attesto/session_state_test.exs
+++ b/test/attesto/session_state_test.exs
@@ -70,6 +70,23 @@ defmodule Attesto.SessionStateTest do
       assert SessionState.origin("/relative/path") == {:error, :invalid_uri}
       assert SessionState.origin("not a uri") == {:error, :invalid_uri}
     end
+
+    test "lowercases scheme and host to match the browser's WHATWG origin" do
+      # The browser reports MessageEvent.origin lowercased; a preserved-case
+      # origin would recompute unequal and answer a permanent false `changed`.
+      assert SessionState.origin("HTTPS://RP.Example.COM/cb") == {:ok, "https://rp.example.com"}
+      assert SessionState.origin("https://RP.Example:8443/cb") == {:ok, "https://rp.example:8443"}
+    end
+
+    test "wraps an IPv6 host in brackets and lowercases its hex" do
+      # URI.parse strips the brackets (host: "2001:DB8::1"); the browser origin
+      # keeps them, so interpolation must re-bracket or it emits a malformed
+      # (and never-matching) origin.
+      assert SessionState.origin("https://[2001:DB8::1]:8443/cb") ==
+               {:ok, "https://[2001:db8::1]:8443"}
+
+      assert SessionState.origin("http://[::1]/cb") == {:ok, "http://[::1]"}
+    end
   end
 
   describe "generated values" do

--- a/test/attesto/session_state_test.exs
+++ b/test/attesto/session_state_test.exs
@@ -36,6 +36,23 @@ defmodule Attesto.SessionStateTest do
       b = SessionState.compute("c", "https://rp.example", "s")
       refute a == b
     end
+
+    test "rejects a caller-supplied salt with a space or a dot" do
+      # A space would violate §2 (no space in session_state); a "." would fight
+      # the `hash "." salt` delimiter the OP iframe splits on. Either makes a
+      # value that could never compare equal in the browser.
+      assert_raise ArgumentError, fn ->
+        SessionState.compute("c", "https://rp.example", "s", "has space")
+      end
+
+      assert_raise ArgumentError, fn ->
+        SessionState.compute("c", "https://rp.example", "s", "has.dot")
+      end
+
+      assert_raise ArgumentError, fn ->
+        SessionState.compute("c", "https://rp.example", "s", "")
+      end
+    end
   end
 
   describe "origin/1" do
@@ -126,6 +143,25 @@ defmodule Attesto.SessionStateTest do
 
       # Splice user-2's login tag onto user-1's value: the MAC no longer covers it.
       refute SessionState.browser_state_valid?(@secret, "#{random}.#{other_tag}.#{mac}", "user-2\n2\n")
+    end
+
+    test "a too-short OP secret is rejected loudly rather than producing forgeable state" do
+      # HMAC-SHA256 accepts any key length, so an empty/short secret yields a MAC
+      # an attacker can recompute. The secret is OP config, so surface the
+      # misconfiguration instead of minting/verifying with it.
+      short = :crypto.strong_rand_bytes(31)
+
+      assert_raise ArgumentError, fn -> SessionState.mint_browser_state(short, @binding) end
+      assert_raise ArgumentError, fn -> SessionState.mint_browser_state("", @binding) end
+
+      # A valid value must not be verifiable under a too-short secret either.
+      value = SessionState.mint_browser_state(@secret, @binding)
+      assert_raise ArgumentError, fn -> SessionState.browser_state_valid?(short, value, @binding) end
+
+      # Exactly 32 bytes is accepted (the boundary).
+      secret32 = :crypto.strong_rand_bytes(32)
+      v = SessionState.mint_browser_state(secret32, @binding)
+      assert SessionState.browser_state_valid?(secret32, v, @binding)
     end
   end
 end


### PR DESCRIPTION
Security hardening from a full-surface adversarial sweep plus three rounds of
external (Codex xhigh) review, all fixes verified against source with
regression tests. All gates green: 1653 tests, `mix credo --strict` clean,
dialyzer clean. Deployed to the conformance OP and smoke-verified end-to-end
(PAR + signed request object → DPoP-bound token → refresh → userinfo; no false
replay rejections).

## Highlights

- **DPoP replay identity namespaced by proof key.** `jti` uniqueness is only
  per-key (RFC 9449 §4.2), so recording the raw `jti` let two keys sharing a
  `jti` collide — a cross-client false replay and a targeted DoS (an
  authenticated attacker pre-burns a victim's `jti` under the attacker's key).
  `verify_proof/2` now returns `replay_key`, a fixed-length `sha256(jkt:jti)`
  digest, recorded by every replay path. **See the CHANGELOG upgrade note re: a
  rolling-deploy replay window from the identity-format change.**
- **Scope-parameter DoS fixed** — `Scope.grants_all?/3` is now linear
  (500k tokens: ~20s → ~40ms).
- **Fail-closed / crash fixes:** DPoP replay TTL off-by-one; IdentityAssertion
  non-integer `nbf`; RequestObject total parameter coercion; CIBA cross-context
  `typ` rejection (RFC 7515 §4.1.9 prefix handling); JARM reserved-claim
  authority (atom/charlist key shadowing); SessionState secret/salt/origin
  hardening.

## Review provenance

Three Codex xhigh rounds: review → fix 8 → verify → fix 3 regressions → verify →
fix 3 transition (docs/telemetry/upgrade-note) items. The steady-state replay
logic was confirmed correct across all four DPoP paths (plug, token endpoint,
PAR, device auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)