### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-02
+
 ### Security
 
 - DPoP replay identities are now namespaced by the proof key. `jti` uniqueness

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.6.0"
+  @version "1.7.0"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 


### PR DESCRIPTION
Version bump to **1.7.0** + CHANGELOG date for the DPoP replay-key namespacing
and full-surface security sweep merged in #18.

Package validated locally (`mix hex.build` → `attesto-1.7.0.tar`). After this
merges, `mix hex.publish` cuts 1.7.0, which unblocks attesto_phoenix#19 (2.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)