### PR TITLE
Add an opt-in loopback matching mode that accepts the localhost name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A third redirect-URI matching mode,
+  `:exact_allow_loopback_port_including_localhost`**, which applies the RFC 8252
+  §7.3 port allowance to the bare hostname `localhost` as well as the
+  `127.0.0.1` / `[::1]` literals.
+
+  Native clients exist that register a portless `http://localhost/callback` in
+  their client-id metadata document and then bind an ephemeral port. Under
+  `:exact_allow_loopback_port` every such request fails
+  `redirect_uri_not_registered`: exact comparison fails on the port, and the
+  §7.3 exception does not cover the name. Claude Code is one such client, so no
+  Attesto deployment could serve it over the loopback flow.
+
+  The literal-IP-only reading remains correct and remains the behavior of
+  `:exact_allow_loopback_port` — §7.3's MUST is scoped to "loopback IP redirect
+  URIs", and 1.4.1's reconciliation of RFC 9700's wider wording still stands.
+  What this adds is the observation that nothing *forbids* a server allowing the
+  name, and that §8.3's case against `localhost` is stated entirely in terms of
+  what the client does (which interface it binds, its firewall, its host-name
+  resolution) — none of which a server changes by refusing the request. The
+  residual risk is the combination of two allowances the module already makes
+  separately: a registered `localhost` URI is already reachable by exact match,
+  and §7.3 port flexibility is already mandated for the IP literals. Permitting
+  only that combination is why this is a separate opt-in rather than a change to
+  the existing mode.
+
+  **No behavior change unless selected.** `:exact` and
+  `:exact_allow_loopback_port` are byte-for-byte as before — `localhost` still
+  gets no port flexibility under either, and the existing test asserting that is
+  unchanged. `localhost` is a distinct host identity from the IP literals and
+  never cross-matches them, and every other constraint is preserved: byte-exact
+  `http://` scheme, anchored authority (`localhost.evil.example`,
+  `sub.localhost`, `evil-localhost`, `localhost.` and userinfo all stay
+  outside), no fragment, exact path and query, and the asymmetric request /
+  registered port rule.
+
 ## [1.8.1] - 2026-08-03
 
 ### Fixed

--- a/lib/attesto/authorization_request.ex
+++ b/lib/attesto/authorization_request.ex
@@ -188,8 +188,12 @@ defmodule Attesto.AuthorizationRequest do
       RFC 8252 §7.3 exception for native apps, under which a loopback redirect
       URI (`http://127.0.0.1/...` or `http://[::1]/...`, never
       `http://localhost/...` - §8.3) matches on any port while scheme, host,
-      path, and query still compare exactly; nothing else is relaxed. Enabling
-      it is a host decision, incompatible with profiles that mandate exact
+      path, and query still compare exactly; nothing else is relaxed.
+      `:exact_allow_loopback_port_including_localhost` extends that same port
+      flexibility to the bare `localhost` name, for native clients that
+      register a portless `localhost` callback and bind an ephemeral port; the
+      name stays a distinct host from the IP literals. Enabling either is a
+      host decision, incompatible with profiles that mandate exact
       redirect-URI matching. An unrecognized value raises `ArgumentError`.
 
     * `:require_nonce` (optional, default `false`) - the host's OP nonce policy.

--- a/lib/attesto/redirect_uri.ex
+++ b/lib/attesto/redirect_uri.ex
@@ -72,9 +72,44 @@ defmodule Attesto.RedirectURI do
       are all identical; only the port is ignored. IPv4 and IPv6 loopback are
       distinct hosts and never match each other.
 
-  Enabling the exception is a deliberate deployment decision: a profile that
-  mandates exact redirect-URI matching forbids it. It is off by default so the
-  matching behavior is unchanged unless a host asks for it.
+    * `:exact_allow_loopback_port_including_localhost` - everything
+      `:exact_allow_loopback_port` does, and additionally treats the bare
+      hostname `localhost` as a loopback authority, so
+      `http://localhost:<ephemeral>/cb` matches a registered
+      `http://localhost/cb`.
+
+      This exists for interoperability, not because §7.3 requires it. §7.3's
+      MUST is scoped to "loopback IP redirect URIs" and the paragraphs above
+      are the right default. But nothing forbids a server allowing the name,
+      and §8.3's case against `localhost` is stated entirely in terms of what
+      the *client* does - it "avoids inadvertently listening on network
+      interfaces other than the loopback interface" and is "less susceptible to
+      client-side firewalls and misconfigured host name resolution on the
+      user's device". Those are reasons for an app author to choose the IP
+      literal; refusing port flexibility at the authorization server does not
+      make any of them true, it only fails the request. Real native clients
+      exist that register a portless `localhost` callback and then bind an
+      ephemeral port, and they cannot authorize at all under the stricter rule.
+
+      The residual risk is bounded by two allowances this module already makes
+      independently: a registered `localhost` URI is already reachable by exact
+      match, so redirecting to a name the server cannot resolve is already
+      accepted; and §7.3 already mandates port flexibility, so a code landing
+      on an arbitrary local port is already accepted for `127.0.0.1`. This mode
+      permits their combination and nothing else, which is why it is a separate
+      opt-in rather than a relaxation of `:exact_allow_loopback_port`.
+
+      `localhost` is its own host identity, never folded onto `127.0.0.1`: the
+      name and the IP literals do not cross-match, exactly as IPv4 and IPv6
+      loopback do not. Every other constraint above is unchanged - byte-exact
+      `http://` scheme, anchored authority (so `localhost.evil.example`,
+      `sub.localhost`, `evil-localhost`, `localhost.` and any userinfo stay
+      outside), no fragment, exact path and query, and the same asymmetric port
+      rule between the request and registered sides.
+
+  Enabling either exception is a deliberate deployment decision: a profile that
+  mandates exact redirect-URI matching forbids them. Both are off by default so
+  the matching behavior is unchanged unless a host asks for it.
 
   ## Registration convention
 
@@ -108,9 +143,9 @@ defmodule Attesto.RedirectURI do
   """
 
   @typedoc "The redirect-URI matching mode (see the moduledoc)."
-  @type matching :: :exact | :exact_allow_loopback_port
+  @type matching :: :exact | :exact_allow_loopback_port | :exact_allow_loopback_port_including_localhost
 
-  @matching_modes [:exact, :exact_allow_loopback_port]
+  @matching_modes [:exact, :exact_allow_loopback_port, :exact_allow_loopback_port_including_localhost]
 
   # RFC 8252 §7.3 covers only `http` on the loopback interface: the connection
   # never leaves the device, so TLS is neither available nor required there.
@@ -127,6 +162,19 @@ defmodule Attesto.RedirectURI do
   # fall back to exact comparison. The port is captured rather than skipped so
   # `port_allowed?/2` can hold the request side to a usable range.
   @loopback_authority ~r/\A(127\.0\.0\.1|\[::1\])(?::([0-9]*))?\z/
+
+  # The same authority, plus the hostname `localhost`, for
+  # `:exact_allow_loopback_port_including_localhost` only. Anchored on the whole
+  # authority exactly as above, so `localhost.evil.example`, `sub.localhost`,
+  # `evil-localhost`, a trailing dot (`localhost.`) and userinfo
+  # (`evil.example@localhost`) all stay outside the exception - only the bare
+  # name, optionally followed by a port, is loopback. Byte-exact like every
+  # other comparison here, so `LOCALHOST` is not the same host as `localhost`.
+  #
+  # `localhost` is captured as itself rather than folded onto `127.0.0.1`, so
+  # the name and the IP literals remain distinct identities and never
+  # cross-match. A client that registers one does not thereby reach the other.
+  @loopback_authority_including_localhost ~r/\A(127\.0\.0\.1|\[::1\]|localhost)(?::([0-9]*))?\z/
 
   # A TCP port a client can actually bind and be redirected to. Port 0 is
   # excluded on the request side: it is the "pick one for me" placeholder, not
@@ -221,7 +269,12 @@ defmodule Attesto.RedirectURI do
     # RFC 8252 §7.3 is an exception applied only after the RFC 6749 §3.1.2.3
     # comparison has already failed, so enabling it can never change the outcome
     # of a request that matched exactly.
-    exact?(uri, registered) or loopback?(uri, registered)
+    exact?(uri, registered) or loopback?(uri, registered, @loopback_authority)
+  end
+
+  def registered?(uri, registered, :exact_allow_loopback_port_including_localhost)
+      when is_binary(uri) and is_list(registered) do
+    exact?(uri, registered) or loopback?(uri, registered, @loopback_authority_including_localhost)
   end
 
   # Exact string comparison (RFC 6749 §3.1.2.3 simple string match). No
@@ -237,14 +290,16 @@ defmodule Attesto.RedirectURI do
   # `loopback_identity/2` means "not a loopback redirect URI", which never
   # matches anything - including another non-loopback URI, since the request
   # side is checked first and short-circuits.
-  defp loopback?(uri, registered) do
-    case loopback_identity(uri, :request) do
+  # `authority` is the pattern defining which hosts count as loopback, so the
+  # mode - not this function - decides whether the `localhost` name is one.
+  defp loopback?(uri, registered, authority) do
+    case loopback_identity(uri, :request, authority) do
       nil ->
         false
 
       identity ->
         Enum.any?(registered, fn candidate ->
-          is_binary(candidate) and loopback_identity(candidate, :registered) == identity
+          is_binary(candidate) and loopback_identity(candidate, :registered, authority) == identity
         end)
     end
   end
@@ -267,21 +322,22 @@ defmodule Attesto.RedirectURI do
   # construction, so any port stands. That is deliberate - `:0` is the
   # conventional placeholder for "an ephemeral port chosen at runtime", and
   # rejecting it would break the natural way to register a loopback callback.
-  defp loopback_identity(uri, role) do
+  defp loopback_identity(uri, role, authority) do
     if String.starts_with?(uri, @http_scheme_prefix) do
-      uri |> URI.parse() |> identity(role)
+      uri |> URI.parse() |> identity(role, authority)
     end
   end
 
-  defp identity(%URI{authority: authority, path: path, query: query, fragment: nil}, role) when is_binary(authority) do
-    case Regex.run(@loopback_authority, authority) do
+  defp identity(%URI{authority: authority, path: path, query: query, fragment: nil}, role, pattern)
+       when is_binary(authority) do
+    case Regex.run(pattern, authority) do
       [_authority, host] -> {host, path, query}
       [_authority, host, port] -> if port_allowed?(port, role), do: {host, path, query}
       nil -> nil
     end
   end
 
-  defp identity(%URI{}, _role), do: nil
+  defp identity(%URI{}, _role, _pattern), do: nil
 
   defp port_allowed?(_port, :registered), do: true
 

--- a/test/attesto/redirect_uri_test.exs
+++ b/test/attesto/redirect_uri_test.exs
@@ -5,7 +5,11 @@ defmodule Attesto.RedirectURITest do
 
   describe "matching_modes/0" do
     test "lists exactly the modes registered?/3 accepts" do
-      assert RedirectURI.matching_modes() == [:exact, :exact_allow_loopback_port]
+      assert RedirectURI.matching_modes() == [
+               :exact,
+               :exact_allow_loopback_port,
+               :exact_allow_loopback_port_including_localhost
+             ]
     end
   end
 
@@ -13,6 +17,9 @@ defmodule Attesto.RedirectURITest do
     test "passes a supported mode through" do
       assert RedirectURI.matching!(:exact) == :exact
       assert RedirectURI.matching!(:exact_allow_loopback_port) == :exact_allow_loopback_port
+
+      assert RedirectURI.matching!(:exact_allow_loopback_port_including_localhost) ==
+               :exact_allow_loopback_port_including_localhost
     end
 
     test "raises on an unrecognized mode rather than silently picking a policy" do
@@ -278,6 +285,111 @@ defmodule Attesto.RedirectURITest do
 
     test "a non-loopback request never matches a loopback registration" do
       refute RedirectURI.registered?("https://evil.example/cb", ["http://127.0.0.1:0/cb"], :exact_allow_loopback_port)
+    end
+  end
+
+  describe "registered?/3 with :exact_allow_loopback_port_including_localhost (RFC 9700 §2.1)" do
+    @mode :exact_allow_loopback_port_including_localhost
+
+    # The reason this mode exists: Claude Code's client-id metadata document
+    # registers a portless `localhost` callback and then binds an ephemeral
+    # port, so the literal-IP-only rule rejects every one of its requests.
+    test "matches the real-world client that motivates the mode" do
+      registered = ["http://localhost/callback", "http://127.0.0.1/callback"]
+
+      assert RedirectURI.registered?("http://localhost:3118/callback", registered, @mode)
+    end
+
+    test "a localhost request matches any registered localhost port" do
+      for registered <- ["http://localhost:0/cb", "http://localhost/cb", "http://localhost:8080/cb"] do
+        assert RedirectURI.registered?("http://localhost:51823/cb", [registered], @mode),
+               "expected #{registered} to match a request on port 51823"
+      end
+    end
+
+    test "it is a superset: literal loopback IPs keep their §7.3 flexibility" do
+      assert RedirectURI.registered?("http://127.0.0.1:51823/cb", ["http://127.0.0.1/cb"], @mode)
+      assert RedirectURI.registered?("http://[::1]:51823/cb", ["http://[::1]:0/cb"], @mode)
+    end
+
+    # `localhost` resolves through the device's host-name configuration and the
+    # literal IPs do not, so they name different things and must not be
+    # interchangeable - exactly as IPv4 and IPv6 loopback are not.
+    test "localhost and the loopback IP literals stay distinct hosts" do
+      refute RedirectURI.registered?("http://localhost:51823/cb", ["http://127.0.0.1:0/cb"], @mode)
+      refute RedirectURI.registered?("http://localhost:51823/cb", ["http://[::1]:0/cb"], @mode)
+      refute RedirectURI.registered?("http://127.0.0.1:51823/cb", ["http://localhost:0/cb"], @mode)
+      refute RedirectURI.registered?("http://[::1]:51823/cb", ["http://localhost:0/cb"], @mode)
+    end
+
+    test "only the port is variable - path and query must still match exactly" do
+      registered = ["http://localhost:0/cb?a=1"]
+
+      refute RedirectURI.registered?("http://localhost:51823/other?a=1", registered, @mode)
+      refute RedirectURI.registered?("http://localhost:51823/cb/?a=1", registered, @mode)
+      refute RedirectURI.registered?("http://localhost:51823/cb?a=2", registered, @mode)
+      refute RedirectURI.registered?("http://localhost:51823/cb", registered, @mode)
+      assert RedirectURI.registered?("http://localhost:51823/cb?a=1", registered, @mode)
+    end
+
+    # §7.3 is an `http`-on-the-loopback-interface exception; widening it to the
+    # name must not also widen it past the scheme.
+    test "https localhost is not relaxed" do
+      refute RedirectURI.registered?("https://localhost:51823/cb", ["https://localhost/cb"], @mode)
+    end
+
+    test "an upper-case scheme is outside the exception" do
+      refute RedirectURI.registered?("HTTP://localhost:51823/cb", ["http://localhost:0/cb"], @mode)
+    end
+
+    # The anchored authority is what keeps `localhost` a name for the loopback
+    # interface rather than a prefix an attacker can extend.
+    test "a host that merely starts or ends with localhost is not loopback" do
+      for uri <- [
+            "http://localhost.evil.example:51823/cb",
+            "http://evil-localhost:51823/cb",
+            "http://localhost.:51823/cb",
+            "http://sub.localhost:51823/cb"
+          ] do
+        refute RedirectURI.registered?(uri, ["http://localhost:0/cb"], @mode),
+               "expected #{uri} to fall outside the loopback exception"
+      end
+    end
+
+    test "userinfo takes the URI outside the exception" do
+      refute RedirectURI.registered?("http://evil.example@localhost:51823/cb", ["http://localhost:0/cb"], @mode)
+      refute RedirectURI.registered?("http://localhost:51823/cb", ["http://evil.example@localhost:0/cb"], @mode)
+    end
+
+    test "a fragment takes the URI outside the exception" do
+      refute RedirectURI.registered?("http://localhost:51823/cb#f", ["http://localhost:0/cb"], @mode)
+    end
+
+    test "a request port outside 1..65535 takes the URI outside the exception" do
+      for uri <- ["http://localhost:0/cb", "http://localhost:/cb", "http://localhost:99999999/cb"] do
+        refute RedirectURI.registered?(uri, ["http://localhost:8080/cb"], @mode),
+               "expected request #{uri} to fall back to exact comparison"
+      end
+    end
+
+    test "the registered side accepts any port, including the :0 placeholder" do
+      for registered <- ["http://localhost:0/cb", "http://localhost:/cb", "http://localhost:99999999/cb"] do
+        assert RedirectURI.registered?("http://localhost:51823/cb", [registered], @mode),
+               "expected registered #{registered} to still match a usable request port"
+      end
+    end
+
+    test "an exact match still wins for a request port the exception would refuse" do
+      assert RedirectURI.registered?("http://localhost:0/cb", ["http://localhost:0/cb"], @mode)
+    end
+
+    test "a remote host is not relaxed" do
+      refute RedirectURI.registered?("http://app.example:51823/cb", ["http://app.example/cb"], @mode)
+      refute RedirectURI.registered?("https://evil.example/cb", ["http://localhost:0/cb"], @mode)
+    end
+
+    test "an empty registered set still matches nothing" do
+      refute RedirectURI.registered?("http://localhost:51823/cb", [], @mode)
     end
   end
 


### PR DESCRIPTION
## Summary

Adds a third opt-in redirect-URI matching mode, `:exact_allow_loopback_port_including_localhost`, which extends the RFC 8252 §7.3 port allowance to the bare hostname `localhost`. The two existing modes are byte-for-byte unchanged, and the existing test asserting that `localhost` is rejected in every form under `:exact_allow_loopback_port` passes unmodified.

## The problem

Native clients exist that register a portless `http://localhost/callback` in their client-id metadata document and then bind an ephemeral port at runtime. Claude Code is the prominent one — its published document at `https://claude.ai/oauth/claude-code-client-metadata` registers exactly:

```json
"redirect_uris": ["http://localhost/callback", "http://127.0.0.1/callback"]
```

and then requests `http://localhost:<ephemeral>/callback`. It requests the **localhost** member, not the IP literal, and it has no fallback: when the authorize request fails it does not retry with `127.0.0.1` and does not fall back to dynamic registration. Under strict matching every such request fails `redirect_uri_not_registered`, so no attesto deployment can serve Claude Code connecting directly to a server URL.

## Why an opt-in mode rather than a change to the existing one

Your CHANGELOG 1.4.1 reading is correct and stays the default: §7.3's MUST is scoped to "loopback IP redirect URIs", and RFC 9700's wider "localhost redirection URIs" phrasing defines the exception by reference back to §7.3. This PR doesn't dispute that — it adds the observation that nothing *forbids* a server allowing the name. §8.3's case against `localhost` is stated entirely in terms of what the client does (which interface it binds, its firewall, its host-name resolution on the user's device); a server refusing the request changes none of those, it only fails the flow.

The residual risk is the combination of two allowances the module already makes separately: a registered `localhost` URI is already reachable by exact match, and §7.3 port flexibility is already mandated for the IP literals. Permitting only that combination is why this is a separate opt-in rather than a loosening of `:exact_allow_loopback_port`.

Worth noting the spec letter is not entirely one-sided either: OAuth 2.1 draft §2.3.1 phrases the registration-matching exception as "loopback redirects, where an exact match is required except for the port URI component" — generic phrasing, with the IP-literal scoping appearing only in §8.4.2's construction text.

## The ecosystem has split on this, and the permissive side is winning on interop

- **Cloudflare `workers-oauth-provider` 0.3.1** ([release notes](https://github.com/cloudflare/workers-oauth-provider/releases/tag/v0.3.1)): "Allow any port for localhost redirect URIs to support native apps that use localhost with ephemeral ports like Claude Code."
- **Sentry's hosted MCP server** hit this exact bug ([#1189](https://github.com/getsentry/sentry-mcp/issues/1189), [#1190](https://github.com/getsentry/sentry-mcp/issues/1190)) and fixed it by honouring loopback ports including localhost ([PR #1188](https://github.com/getsentry/sentry-mcp/pull/1188), merged).
- **Directus** and **PostHog** ship the same localhost-inclusive matching.
- **Obot** instead hardcodes Claude Code's `client_id` URL as a "native exception" in source — the shape of workaround this mode exists to avoid.
- **Ory Hydra/fosite** and **Spring Authorization Server** remain literal-IP-only — strict company, but their deployments cannot serve Claude Code direct connections either.

## What's preserved

`localhost` is its own host identity and never cross-matches `127.0.0.1` or `[::1]`, exactly as IPv4 and IPv6 loopback never cross-match. Every other constraint is unchanged: byte-exact `http://` scheme, anchored authority (`localhost.evil.example`, `sub.localhost`, `evil-localhost`, `localhost.`, and userinfo all stay outside), no fragment, exact path and query, and the asymmetric request/registered port rule.

Suite passes (the 10 pre-existing Python cross-language parity failures fail identically on clean `main`); `credo --strict` and `mix format --check-formatted` clean.

A companion PR against `attesto_phoenix` wires the mode to a `native_apps: [loopback_include_localhost: true]` deployment option; happy to adjust either to taste — including the mode name, which is a mouthful.
