### PR TITLE
Add follow-up coverage for localhost loopback matching

### DIFF
--- a/test/attesto/authorization_request_loopback_redirect_test.exs
+++ b/test/attesto/authorization_request_loopback_redirect_test.exs
@@ -3,10 +3,9 @@ defmodule Attesto.AuthorizationRequestLoopbackRedirectTest do
   RFC 8252 §7.3 loopback interface redirection, exercised through the public
   `Attesto.AuthorizationRequest.validate/2` surface.
 
-  Every case is run in both configurations - the default `:exact` and the opt-in
-  `:exact_allow_loopback_port` - because the guarantee under test is as much
-  "nothing changes unless the host asks for it" as it is "the loopback port
-  varies when it does".
+  Cases exercise the default `:exact` mode and both opt-in loopback modes,
+  because the guarantee under test is as much "nothing changes unless the host
+  asks for it" as it is "the loopback port varies when it does".
   """
 
   use ExUnit.Case, async: true
@@ -41,6 +40,10 @@ defmodule Attesto.AuthorizationRequestLoopbackRedirectTest do
 
   defp validate_loopback(redirect_uri, registered) do
     validate(redirect_uri, registered, redirect_uri_matching: :exact_allow_loopback_port)
+  end
+
+  defp validate_loopback_including_localhost(redirect_uri, registered) do
+    validate(redirect_uri, registered, redirect_uri_matching: :exact_allow_loopback_port_including_localhost)
   end
 
   describe "default matching (RFC 6749 §3.1.2.3)" do
@@ -163,6 +166,19 @@ defmodule Attesto.AuthorizationRequestLoopbackRedirectTest do
                  registered_redirect_uris: ["http://127.0.0.1:0/cb"],
                  redirect_uri_matching: :exact
                )
+    end
+  end
+
+  describe "localhost-inclusive loopback redirection" do
+    test "the opt-in mode is wired through AuthorizationRequest.validate/2" do
+      registered = ["http://localhost/callback"]
+      requested = "http://localhost:51823/callback"
+
+      assert {:ok, request} = validate_loopback_including_localhost(requested, registered)
+      assert request.redirect_uri == requested
+
+      assert {:error, {:direct, :redirect_uri_not_registered}} = validate_loopback(requested, registered)
+      assert {:error, {:direct, :redirect_uri_not_registered}} = validate_exact(requested, registered)
     end
   end
 

--- a/test/attesto/redirect_uri_test.exs
+++ b/test/attesto/redirect_uri_test.exs
@@ -307,6 +307,10 @@ defmodule Attesto.RedirectURITest do
       end
     end
 
+    test "a portless localhost request matches a registration with a fixed port" do
+      assert RedirectURI.registered?("http://localhost/cb", ["http://localhost:8080/cb"], @mode)
+    end
+
     test "it is a superset: literal loopback IPs keep their §7.3 flexibility" do
       assert RedirectURI.registered?("http://127.0.0.1:51823/cb", ["http://127.0.0.1/cb"], @mode)
       assert RedirectURI.registered?("http://[::1]:51823/cb", ["http://[::1]:0/cb"], @mode)
@@ -361,8 +365,13 @@ defmodule Attesto.RedirectURITest do
       refute RedirectURI.registered?("http://localhost:51823/cb", ["http://evil.example@localhost:0/cb"], @mode)
     end
 
-    test "a fragment takes the URI outside the exception" do
+    test "a fragment on either side takes the URI outside the exception" do
       refute RedirectURI.registered?("http://localhost:51823/cb#f", ["http://localhost:0/cb"], @mode)
+      refute RedirectURI.registered?("http://localhost:51823/cb", ["http://localhost:0/cb#f"], @mode)
+    end
+
+    test "a malformed port takes the URI outside the exception" do
+      refute RedirectURI.registered?("http://localhost:abc/cb", ["http://localhost:0/cb"], @mode)
     end
 
     test "a request port outside 1..65535 takes the URI outside the exception" do

--- a/test/parity/redirect_uri_whatwg_parity_test.exs
+++ b/test/parity/redirect_uri_whatwg_parity_test.exs
@@ -49,10 +49,12 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
   # The hosts RFC 8252 §7.3 sanctions, as WHATWG spells them. `[::1]` is
   # reported bracketed by `URL.hostname`.
   @loopback_hosts ["127.0.0.1", "[::1]"]
+  @loopback_hosts_including_localhost @loopback_hosts ++ ["localhost"]
 
   # What a native app would plausibly register: the loopback callback in both
   # address families, port `0` by convention (§7.3 ignores it).
   @registered ["http://127.0.0.1:0/cb", "http://[::1]:0/cb"]
+  @registered_including_localhost @registered ++ ["http://localhost:0/cb"]
 
   # Legitimate loopback requests, adversarial near-misses, and the encodings an
   # attacker would reach for to smuggle a non-loopback host past a matcher.
@@ -82,13 +84,30 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
     "http://[::1%25eth0]:51823/cb",
     # The hostname §8.3 rules out.
     "http://localhost:51823/cb",
+    "http://localhost/cb",
+    "http://localhost:1/cb",
+    "http://localhost:65535/cb",
     "http://LOCALHOST:51823/cb",
+    "http://localhost.evil.example:51823/cb",
+    "http://evil-localhost:51823/cb",
+    "http://localhost.:51823/cb",
+    "http://evil.example@localhost:51823/cb",
+    "http://localhost:51823@evil.example/cb",
+    "http://localhost\\@evil.example/cb",
+    "http://localhost\t@evil.example/cb",
+    "http://localhost\n@evil.example/cb",
+    "http://local%68ost:51823/cb",
     # Port edge cases.
     "http://127.0.0.1:/cb",
     "http://127.0.0.1:0/cb",
     "http://127.0.0.1:65536/cb",
     "http://127.0.0.1:0080/cb",
     "http://127.0.0.1:99999999999/cb",
+    "http://localhost:/cb",
+    "http://localhost:0/cb",
+    "http://localhost:65536/cb",
+    "http://localhost:abc/cb",
+    "http://localhost:99999999999/cb",
     # Scheme variants outside the exception.
     "HTTP://127.0.0.1:51823/cb",
     "https://127.0.0.1:51823/cb",
@@ -106,7 +125,9 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
   defp unbracket(host) when is_binary(host), do: String.trim_leading(host, "[") |> String.trim_trailing("]")
   defp unbracket(host), do: host
 
-  defp accepted?(uri, matching), do: RedirectURI.registered?(uri, @registered, matching)
+  defp accepted?(uri, matching, registered \\ @registered) do
+    RedirectURI.registered?(uri, registered, matching)
+  end
 
   describe "the accept-set never escapes loopback (RFC 8252 §7.3)" do
     test "every URI the loopback rule accepts resolves to a loopback host in a browser" do
@@ -146,6 +167,33 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
       assert offenders == []
     end
 
+    test "the localhost-inclusive rule stays within its explicit host set" do
+      offenders =
+        for uri <- @corpus,
+            accepted?(uri, :exact_allow_loopback_port_including_localhost, @registered_including_localhost) do
+          parsed = whatwg(uri)
+
+          cond do
+            parsed["ok"] != true ->
+              {uri, "WHATWG refuses to parse it, so it names no reachable target"}
+
+            parsed["hostname"] not in @loopback_hosts_including_localhost ->
+              {uri, "browser resolves host to #{inspect(parsed["hostname"])}"}
+
+            parsed["protocol"] != "http:" ->
+              {uri, "browser resolves scheme to #{inspect(parsed["protocol"])}"}
+
+            true ->
+              nil
+          end
+        end
+        |> Enum.reject(&is_nil/1)
+
+      assert offenders == [],
+             "accepted redirect URIs that a browser would send outside the explicit loopback host set:\n" <>
+               Enum.map_join(offenders, "\n", fn {uri, why} -> "  #{inspect(uri)} - #{why}" end)
+    end
+
     test "the corpus actually exercises the rule (guards against a vacuous pass)" do
       # If the matcher were replaced by `fn _, _, _ -> false end` the invariant
       # tests above would pass trivially. Pin that some URIs really are
@@ -157,6 +205,21 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
       assert "http://[::1]:51823/cb" in loopback
       refute "http://127.0.0.1:51823/cb" in exact
       assert length(loopback) > length(exact)
+    end
+
+    test "the localhost-inclusive corpus exercises the additional branch" do
+      inclusive =
+        Enum.filter(
+          @corpus,
+          &accepted?(&1, :exact_allow_loopback_port_including_localhost, @registered_including_localhost)
+        )
+
+      strict = Enum.filter(@corpus, &accepted?(&1, :exact_allow_loopback_port))
+
+      assert "http://localhost:51823/cb" in inclusive
+      assert "http://localhost/cb" in inclusive
+      refute "http://localhost:51823/cb" in strict
+      assert length(inclusive) > length(strict)
     end
   end
 
@@ -175,6 +238,16 @@ defmodule Attesto.Parity.RedirectURIWhatwgParityTest do
 
       refute accepted?(uri, :exact_allow_loopback_port)
       refute accepted?(uri, :exact)
+    end
+
+    test "a backslash cannot extend localhost into an attacker-controlled authority" do
+      uri = "http://localhost\\@evil.example/cb"
+      parsed = whatwg(uri)
+
+      assert parsed["hostname"] == "localhost"
+      assert URI.parse(uri).host == "evil.example"
+
+      refute accepted?(uri, :exact_allow_loopback_port_including_localhost, @registered_including_localhost)
     end
 
     # Deliberately asserts nothing about what the reference parser returns for


### PR DESCRIPTION
## Summary

Follow-up coverage for #20, with no production-code changes:

- add the missing unit cases for a portless request, an alphabetic port, and a fragment on the registered side
- exercise `:exact_allow_loopback_port_including_localhost` through the public `AuthorizationRequest.validate/2` path and verify both stricter modes still reject the differing port
- extend the existing WHATWG browser-parser parity suite to the localhost-inclusive mode, including authority confusion, encoded-host, host-suffix, control-character, and port-boundary inputs

The parity suite already covered the IP-literal mode; this extends the same invariant to the new explicit host set and includes a non-vacuity check proving the additional branch runs.

## Verification

```text
ERL_COMPILER_OPTIONS='[nowarn_deprecated_catch]' mix precommit
Result: 2035 passed (68 properties, 1967 tests)
Credo strict: no issues
Format and warnings-as-errors compile: clean
```
