### PR TITLE
Release 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-08-05
+
 ### Added
 
 - **A third redirect-URI matching mode,

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "1.8.1"
+  @version "1.9.0"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 


### PR DESCRIPTION
Version bump to **1.9.0** and changelog date for the opt-in localhost loopback matching mode merged in #20, plus the follow-up coverage in #21.

This is an additive public API, so a minor release is appropriate. Existing matching modes and defaults remain unchanged.

Package validation:

```text
ERL_COMPILER_OPTIONS='[nowarn_deprecated_catch]' mix precommit
Result: 2035 passed (68 properties, 1967 tests)

mix hex.build
Package: attesto-1.9.0.tar
Checksum: 3e8e88cb3000cf72ef55cbd9f5ac10a216bc729f824408b1b0b3d1e9a58c02de
```

After this merges, publishing 1.9.0 to Hex will let the Phoenix integration require the first core version that implements the new matching mode.
