### PR TITLE
Reject structs at the portable JSON boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Make `Attesto.Claims.portable_json_object?/1` return `false` for structs at
+  any nesting level instead of raising while attempting to enumerate them.
+
 ## [2.0.0] - 2026-08-31
 
 ### Breaking

--- a/lib/attesto/claims.ex
+++ b/lib/attesto/claims.ex
@@ -63,6 +63,8 @@ defmodule Attesto.Claims do
 
   defp portable_json_array_tail?(_improper_tail, _depth), do: false
 
+  defp portable_json_object?(value, _depth) when is_struct(value), do: false
+
   defp portable_json_object?(value, depth) when is_map(value) and depth <= @max_portable_json_depth do
     Enum.all?(value, fn {key, member} -> portable_json_string?(key) and portable_json_value?(member, depth) end)
   end

--- a/test/attesto/claims_test.exs
+++ b/test/attesto/claims_test.exs
@@ -34,6 +34,14 @@ defmodule Attesto.ClaimsTest do
       refute Claims.portable_json_object?(%{"bitstring" => <<1::size(1)>>})
     end
 
+    test "returns false for structs at the root or nested in otherwise portable values" do
+      for struct <- [~D[2026-09-02], ~U[2026-09-02 00:00:00Z], MapSet.new(["member"])] do
+        refute Claims.portable_json_object?(struct)
+        refute Claims.portable_json_object?(%{"nested" => struct})
+        refute Claims.portable_json_object?(%{"nested" => [%{"value" => struct}]})
+      end
+    end
+
     test "rejects invalid UTF-8 binaries while accepting empty objects and arrays" do
       assert Claims.portable_json_object?(%{"empty_object" => %{}, "empty_array" => []})
       refute Claims.portable_json_object?(%{"invalid_utf8" => <<255>>})


### PR DESCRIPTION
## Summary

- make `Attesto.Claims.portable_json_object?/1` total for structs
- reject structs consistently at the root and through nested maps/lists
- add root and nested regression coverage

## Verification

- 2,233 tests passed; 42 skipped
- docs built with warnings as errors
- Dialyzer passed
- Hex dependency audit passed
- manual root/nested checks covered Date, DateTime, MapSet, URI, Range, and Regex
