### PR TITLE
Prepare Attesto 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-09-02
+
 ### Fixed
 
 - Make `Attesto.Claims.portable_json_object?/1` return `false` for structs at

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Attesto.MixProject do
   alias Attesto.Test.DPoP, as: TestDPoP
   alias Attesto.Test.DPoPVerifier, as: TestDPoPVerifier
 
-  @version "2.0.0"
+  @version "2.0.1"
   @url "https://github.com/XukuLLC/attesto"
   @maintainers ["Neil Berkman"]
 


### PR DESCRIPTION
## Summary

- set the package version to 2.0.1
- publish the portable-JSON struct fix in the 2.0.1 changelog section

## Release gates

- precommit: 2,233 passed; 42 skipped
- docs with warnings as errors: passed
- Dialyzer: passed
- Hex dependency audit: clean
- Hex package build and archive inspection: passed
